### PR TITLE
chore(ci): bump actions y exime dependabot de checks de convenciones

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,8 +18,8 @@ jobs:
     name: Lint + type
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@v6
+      - uses: actions/setup-python@v6
         with:
           python-version: "3.11"
           cache: pip
@@ -37,8 +37,8 @@ jobs:
         os: [ubuntu-latest, windows-latest, macos-latest]
         python: ["3.11", "3.12"]
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@v6
+      - uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.python }}
           cache: pip
@@ -47,7 +47,7 @@ jobs:
         run: pytest -m "not integration" --cov=src/nz_mcp --cov-report=xml
       - name: Upload coverage artifact
         if: matrix.os == 'ubuntu-latest' && matrix.python == '3.11'
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: coverage
           path: coverage.xml

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -22,7 +22,7 @@ jobs:
       matrix:
         language: [python]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: github/codeql-action/init@v3
         with:
           languages: ${{ matrix.language }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,10 +14,10 @@ jobs:
     runs-on: ubuntu-latest
     environment: pypi
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v6
         with:
           python-version: "3.11"
       - run: pip install build

--- a/.github/workflows/sync-labels.yml
+++ b/.github/workflows/sync-labels.yml
@@ -16,7 +16,7 @@ jobs:
     name: Sync labels from .github/labels.yml
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: EndBug/label-sync@v2
         with:
           config-file: .github/labels.yml

--- a/.github/workflows/validate-conventions.yml
+++ b/.github/workflows/validate-conventions.yml
@@ -14,11 +14,17 @@ jobs:
     name: Branch name
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - name: Skip for bots
+        if: github.actor == 'dependabot[bot]'
+        run: echo "Skipping for ${{ github.actor }} — bots use their own naming."
+      - uses: actions/checkout@v6
+        if: github.actor != 'dependabot[bot]'
+      - uses: actions/setup-python@v6
+        if: github.actor != 'dependabot[bot]'
         with:
           python-version: "3.11"
       - name: Validate branch name
+        if: github.actor != 'dependabot[bot]'
         run: |
           BRANCH="${{ github.head_ref }}"
           echo "Branch: $BRANCH"
@@ -46,8 +52,8 @@ jobs:
     name: PR title
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@v6
+      - uses: actions/setup-python@v6
         with:
           python-version: "3.11"
       - name: Validate PR title
@@ -59,7 +65,11 @@ jobs:
     name: PR body has Closes/Refs
     runs-on: ubuntu-latest
     steps:
+      - name: Skip for bots
+        if: github.actor == 'dependabot[bot]'
+        run: echo "Skipping for ${{ github.actor }} — bots have their own PR body format."
       - name: Verify Closes #N or Refs #N
+        if: github.actor != 'dependabot[bot]'
         env:
           PR_BODY: ${{ github.event.pull_request.body }}
         run: |
@@ -75,10 +85,10 @@ jobs:
     name: Commit subjects
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v6
         with:
           python-version: "3.11"
       - name: Validate every commit subject in PR


### PR DESCRIPTION
## ¿Qué cambia?
1. Bump de GitHub Actions:
   - `actions/checkout` v4 → v6
   - `actions/setup-python` v5 → v6
   - `actions/upload-artifact` v4 → v7
2. Los jobs `branch-name` y `pr-body` de `validate-conventions.yml` se ejecutan vacíos cuando `github.actor == 'dependabot[bot]'` (el job aparece como verde sin validar nada). Razón: Dependabot usa su propio naming de branches y formato de PR body que no podemos forzar a conventional. El job `commits` se mantiene porque ya cumple gracias a `commit-message.prefix=chore` en `dependabot.yml`.

## Issue relacionado
Closes #9

## Acción según AGENTS.md
- **Ruta (keywords)**: `CI`, `GitHub Actions`, `dependabot`
- **Docs leídos**: docs/standards/git-workflow.md, docs/standards/pr-audit.md, docs/roles/release-engineer.md
- **Rol asumido**: Release Engineer

## Auditoría pre-merge — 7 dimensiones

### 1. Contrato y compatibilidad
- [x] Sin cambios al contrato de tools.
- [x] Sin cambios observables al usuario externo (CHANGELOG no requiere entrada).

### 2. Seguridad
- [x] No se debilita ninguna barrera defensiva.
- [x] Bumps son a major versions probadas por la comunidad.

### 3. Mantenibilidad y diseño
- [x] Solo 5 archivos de workflows, todos cambios pequeños.
- [x] Una intención sola.

### 4. Tests
- [x] N/A. CI verde lo prueba.

### 5. Tipado y estilo
- [x] N/A.

### 6. Documentación
- [x] Issue #9 documenta la decisión.

### 7. Idioma y forma
- [x] Título PR en español, conventional.
- [x] Branch `chore/9-bump-actions-y-skip-dependabot` cumple regex.
- [x] Commit en español.

## Validación humana requerida
- [ ] No

## Notas para el auditor
Tras merge, los 3 PRs auto-generados de Dependabot (#1, #2, #3) quedan obsoletos y se cierran con comentario.