### PR TITLE
feat(cli): añade comando nz-mcp doctor para diagnóstico local

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ Cada entrada se documenta en **español** y **english**.
 ## [Unreleased]
 
 ### Added
+- ES: comando CLI `nz-mcp doctor` con diagnóstico local (sin red/Netezza) e informe i18n ES/EN.
+- EN: `nz-mcp doctor` CLI for local diagnostics (no network/Netezza) with ES/EN i18n report.
 - ES: estructura inicial del repositorio con `AGENTS.md` como router de despacho para agentes IA.
 - EN: initial repository scaffolding with `AGENTS.md` as dispatch router for AI agents.
 - ES: docs completas de arquitectura, roles senior (×8), estándares y ADRs (×7).
@@ -25,7 +27,7 @@ Cada entrada se documenta en **español** y **english**.
 - EN: credentials management via OS-native `keyring` + TOML profiles.
 - ES: catálogo i18n ES/EN para mensajes de error y hints.
 - EN: ES/EN i18n catalog for error messages and hints.
-- ES: CLI `nz-mcp init`, `add-profile`, `list-profiles`, `test-connection`, `serve`.
-- EN: `nz-mcp init`, `add-profile`, `list-profiles`, `test-connection`, `serve` CLI.
+- ES: CLI `nz-mcp init`, `add-profile`, `list-profiles`, `doctor`, `test-connection`, `serve`.
+- EN: `nz-mcp init`, `add-profile`, `list-profiles`, `doctor`, `test-connection`, `serve` CLI.
 - ES: CI con lint, type-check, tests y validación de convenciones (branches, commits, PRs).
 - EN: CI with lint, type-check, tests and convention validation (branches, commits, PRs).

--- a/README.en.md
+++ b/README.en.md
@@ -47,6 +47,29 @@ nz-mcp init        # interactive wizard
 
 Restart Claude Desktop and ask: *"list the databases on my Netezza"*.
 
+### Diagnostics
+
+To inspect your local environment (Python version, config paths, profile names without credentials, keyring) **without connecting to Netezza**:
+
+```bash
+nz-mcp doctor
+```
+
+Sample output (abbreviated):
+
+```text
+Local diagnostics (nz-mcp doctor)
+
+nz-mcp version: 0.1.0a0
+Python version: 3.11.x
+...
+Profile names: dev, prod
+Active profile: dev
+...
+```
+
+Exit code: `0` when the setup is OK; `1` on a critical issue (e.g. keyring unavailable).
+
 ## Available tools (24)
 
 Full contract: [`docs/architecture/tools-contract.md`](docs/architecture/tools-contract.md).

--- a/README.md
+++ b/README.md
@@ -47,6 +47,29 @@ nz-mcp init        # wizard interactivo: host, port, db, user, password, mode
 
 Reinicia Claude Desktop y pídele: *"lista las bases de datos de mi Netezza"*.
 
+### Diagnóstico
+
+Para revisar el entorno local (versión de Python, rutas de config, perfiles sin credenciales, keyring) **sin conectar a Netezza**:
+
+```bash
+nz-mcp doctor
+```
+
+Ejemplo de salida (resumido):
+
+```text
+Diagnóstico local (nz-mcp doctor)
+
+Versión nz-mcp: 0.1.0a0
+Versión de Python: 3.11.x
+...
+Nombres de perfiles: dev, prod
+Perfil activo: dev
+...
+```
+
+Código de salida: `0` si el entorno es usable; `1` si hay un problema crítico (p. ej. keyring no disponible).
+
 ## Tools disponibles (24)
 
 Ver el contrato completo en [`docs/architecture/tools-contract.md`](docs/architecture/tools-contract.md).

--- a/src/nz_mcp/cli.py
+++ b/src/nz_mcp/cli.py
@@ -4,6 +4,7 @@ Commands:
 - ``init``               first-time wizard: creates the first profile.
 - ``add-profile``        add another profile.
 - ``list-profiles``      list configured profiles.
+- ``doctor``             print local diagnostics (no Netezza connection).
 - ``test-connection``    verify the active profile (stubbed in v0.1.0a0).
 - ``serve``              run the MCP server over stdio (stubbed in v0.1.0a0).
 - ``version``            print the package version.
@@ -27,6 +28,8 @@ from nz_mcp.config import (
     list_profile_names,
     profiles_path,
 )
+from nz_mcp.diagnostic import collect_diagnostic, format_diagnostic_report
+from nz_mcp.i18n import resolve_locale
 
 app = typer.Typer(
     name="nz-mcp",
@@ -69,6 +72,15 @@ def list_profiles_cmd() -> None:
         raise typer.Exit(code=0)
     for n in names:
         typer.echo(n)
+
+
+@app.command("doctor")
+def doctor_cmd() -> None:
+    """Print local diagnostics (package, Python, profiles metadata, keyring) — no Netezza."""
+    report = collect_diagnostic()
+    locale = resolve_locale()
+    typer.echo(format_diagnostic_report(report, locale=locale))
+    raise typer.Exit(code=0 if report.is_healthy else 1)
 
 
 @app.command("test-connection")

--- a/src/nz_mcp/diagnostic.py
+++ b/src/nz_mcp/diagnostic.py
@@ -1,0 +1,186 @@
+"""Local environment diagnostics for ``nz-mcp doctor`` (no network, no Netezza).
+
+Collects non-sensitive metadata only: never hostnames, usernames, passwords, or keyring secrets.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import platform
+import sys
+from pathlib import Path
+
+import keyring
+from keyring.backends.fail import Keyring as FailKeyring
+from pydantic import BaseModel, ConfigDict
+
+from nz_mcp import __version__
+from nz_mcp.config import (
+    _single_profile_or_none,
+    config_dir,
+    load_profiles_file,
+    profiles_path,
+)
+from nz_mcp.errors import InvalidProfileError
+from nz_mcp.i18n import Locale, resolve_locale, t
+
+
+class DiagnosticReport(BaseModel):
+    """Structured diagnostic data (safe to JSON-serialize; no credentials)."""
+
+    model_config = ConfigDict(frozen=True)
+
+    nz_mcp_version: str
+    python_version: str
+    platform: str
+    config_dir: str
+    config_dir_exists: bool
+    config_dir_writable: bool
+    profiles_path: str
+    profiles_path_exists: bool
+    profiles_load_ok: bool
+    profiles_count: int
+    profiles_names: tuple[str, ...]
+    active_profile: str | None
+    keyring_backend: str
+    keyring_available: bool
+    locale: Locale
+
+    @property
+    def is_healthy(self) -> bool:
+        """False when a critical local setup issue is detected."""
+        return self.config_dir_writable and self.keyring_available
+
+
+def _writable_dir(path: Path) -> bool:
+    """Return whether ``path`` can be used as a writable config directory."""
+    try:
+        target = path.expanduser().resolve()
+    except OSError:
+        return False
+    cur: Path = target
+    while True:
+        if cur.exists():
+            return cur.is_dir() and os.access(cur, os.W_OK)
+        if cur.parent == cur:
+            return False
+        cur = cur.parent
+
+
+def _probe_keyring() -> tuple[str, bool]:
+    """Return ``(backend_class_name, available)`` using a non-destructive probe."""
+    try:
+        backend = keyring.get_keyring()
+    except Exception:
+        return ("<unavailable>", False)
+    name = backend.__class__.__name__
+    if isinstance(backend, FailKeyring):
+        return (name, False)
+    return (name, True)
+
+
+def collect_diagnostic(
+    *,
+    profiles_file: Path | None = None,
+    config_dir_override: Path | None = None,
+) -> DiagnosticReport:
+    """Gather diagnostic fields without printing or touching Netezza.
+
+    Parameters are for tests; production uses ``config_dir()`` / ``profiles_path()``.
+    """
+    cfg = (config_dir_override or config_dir()).expanduser().resolve()
+    pp = profiles_file if profiles_file is not None else profiles_path()
+    pp = pp.expanduser().resolve()
+
+    loc = resolve_locale()
+    py_ver = ".".join(str(x) for x in sys.version_info[:3])
+    plat = platform.platform()
+
+    profiles_load_ok = True
+    profiles_count = 0
+    profiles_names: tuple[str, ...] = ()
+    active_profile: str | None = None
+
+    if pp.exists():
+        try:
+            data = load_profiles_file(pp)
+        except InvalidProfileError:
+            profiles_load_ok = False
+        else:
+            profiles_count = len(data.profiles)
+            profiles_names = tuple(sorted(data.profiles.keys()))
+            active_profile = (
+                data.active or os.environ.get("NZ_MCP_PROFILE") or _single_profile_or_none(data)
+            )
+
+    kr_name, kr_ok = _probe_keyring()
+
+    return DiagnosticReport(
+        nz_mcp_version=__version__,
+        python_version=py_ver,
+        platform=plat,
+        config_dir=str(cfg),
+        config_dir_exists=cfg.exists(),
+        config_dir_writable=_writable_dir(cfg),
+        profiles_path=str(pp),
+        profiles_path_exists=pp.exists(),
+        profiles_load_ok=profiles_load_ok,
+        profiles_count=profiles_count,
+        profiles_names=profiles_names,
+        active_profile=active_profile,
+        keyring_backend=kr_name,
+        keyring_available=kr_ok,
+        locale=loc,
+    )
+
+
+def format_diagnostic_report(report: DiagnosticReport, *, locale: Locale | None = None) -> str:
+    """Render a human-readable, localized table (no secrets)."""
+    loc = resolve_locale(locale)
+
+    def lbl(key: str) -> str:
+        return t(key, loc)
+
+    yes = lbl("DOCTOR.BOOL_YES")
+    no = lbl("DOCTOR.BOOL_NO")
+
+    def yn(b: bool) -> str:
+        return yes if b else no
+
+    lines = [
+        lbl("DOCTOR.HEADER"),
+        "",
+        f"{lbl('DOCTOR.LABEL.NZ_MCP_VERSION')}: {report.nz_mcp_version}",
+        f"{lbl('DOCTOR.LABEL.PYTHON_VERSION')}: {report.python_version}",
+        f"{lbl('DOCTOR.LABEL.PLATFORM')}: {report.platform}",
+        f"{lbl('DOCTOR.LABEL.CONFIG_DIR')}: {report.config_dir}",
+        f"  {lbl('DOCTOR.LABEL.EXISTS')}: {yn(report.config_dir_exists)}",
+        f"  {lbl('DOCTOR.LABEL.WRITABLE')}: {yn(report.config_dir_writable)}",
+        f"{lbl('DOCTOR.LABEL.PROFILES_PATH')}: {report.profiles_path}",
+        f"  {lbl('DOCTOR.LABEL.EXISTS')}: {yn(report.profiles_path_exists)}",
+        f"{lbl('DOCTOR.LABEL.PROFILES_LOAD_OK')}: {yn(report.profiles_load_ok)}",
+        f"{lbl('DOCTOR.LABEL.PROFILES_COUNT')}: {report.profiles_count}",
+        (
+            f"{lbl('DOCTOR.LABEL.PROFILES_NAMES')}: "
+            f"{', '.join(report.profiles_names) or lbl('DOCTOR.NONE')}"
+        ),
+        f"{lbl('DOCTOR.LABEL.ACTIVE_PROFILE')}: {report.active_profile or lbl('DOCTOR.NONE')}",
+        f"{lbl('DOCTOR.LABEL.KEYRING_BACKEND')}: {report.keyring_backend}",
+        f"  {lbl('DOCTOR.LABEL.AVAILABLE')}: {yn(report.keyring_available)}",
+        f"{lbl('DOCTOR.LABEL.LOCALE')}: {report.locale}",
+    ]
+
+    if not report.is_healthy:
+        lines.extend(["", lbl("DOCTOR.CRITICAL_HEADER")])
+        if not report.config_dir_writable:
+            lines.append(f"- {lbl('DOCTOR.CRITICAL.CONFIG_DIR_NOT_WRITABLE')}")
+        if not report.keyring_available:
+            lines.append(f"- {lbl('DOCTOR.CRITICAL.KEYRING_UNAVAILABLE')}")
+
+    return "\n".join(lines)
+
+
+def report_json_for_audit(report: DiagnosticReport) -> str:
+    """JSON snapshot for tests (ensures no accidental sensitive fields)."""
+    return json.dumps(report.model_dump(mode="json"), sort_keys=True)

--- a/src/nz_mcp/i18n.py
+++ b/src/nz_mcp/i18n.py
@@ -79,6 +79,91 @@ MESSAGES: Final[dict[str, Message]] = {
         "es": "La query tardó {ms}ms, cerca del timeout. Considera filtrar más.",
         "en": "Query took {ms}ms, near timeout. Consider filtering further.",
     },
+    # nz-mcp doctor (CLI diagnostics — no secrets)
+    "DOCTOR.HEADER": {
+        "es": "Diagnóstico local (nz-mcp doctor)",
+        "en": "Local diagnostics (nz-mcp doctor)",
+    },
+    "DOCTOR.BOOL_YES": {
+        "es": "sí",
+        "en": "yes",
+    },
+    "DOCTOR.BOOL_NO": {
+        "es": "no",
+        "en": "no",
+    },
+    "DOCTOR.NONE": {
+        "es": "(ninguno)",
+        "en": "(none)",
+    },
+    "DOCTOR.LABEL.NZ_MCP_VERSION": {
+        "es": "Versión nz-mcp",
+        "en": "nz-mcp version",
+    },
+    "DOCTOR.LABEL.PYTHON_VERSION": {
+        "es": "Versión de Python",
+        "en": "Python version",
+    },
+    "DOCTOR.LABEL.PLATFORM": {
+        "es": "Plataforma",
+        "en": "Platform",
+    },
+    "DOCTOR.LABEL.CONFIG_DIR": {
+        "es": "Directorio de configuración",
+        "en": "Configuration directory",
+    },
+    "DOCTOR.LABEL.EXISTS": {
+        "es": "Existe",
+        "en": "Exists",
+    },
+    "DOCTOR.LABEL.WRITABLE": {
+        "es": "Escribible",
+        "en": "Writable",
+    },
+    "DOCTOR.LABEL.PROFILES_PATH": {
+        "es": "Ruta de perfiles",
+        "en": "Profiles path",
+    },
+    "DOCTOR.LABEL.PROFILES_LOAD_OK": {
+        "es": "Carga de perfiles OK",
+        "en": "Profiles load OK",
+    },
+    "DOCTOR.LABEL.PROFILES_COUNT": {
+        "es": "Número de perfiles",
+        "en": "Profile count",
+    },
+    "DOCTOR.LABEL.PROFILES_NAMES": {
+        "es": "Nombres de perfiles",
+        "en": "Profile names",
+    },
+    "DOCTOR.LABEL.ACTIVE_PROFILE": {
+        "es": "Perfil activo",
+        "en": "Active profile",
+    },
+    "DOCTOR.LABEL.KEYRING_BACKEND": {
+        "es": "Backend de keyring",
+        "en": "Keyring backend",
+    },
+    "DOCTOR.LABEL.AVAILABLE": {
+        "es": "Disponible",
+        "en": "Available",
+    },
+    "DOCTOR.LABEL.LOCALE": {
+        "es": "Idioma (locale)",
+        "en": "Locale",
+    },
+    "DOCTOR.CRITICAL_HEADER": {
+        "es": "Problemas críticos detectados:",
+        "en": "Critical issues detected:",
+    },
+    "DOCTOR.CRITICAL.CONFIG_DIR_NOT_WRITABLE": {
+        "es": "El directorio de configuración no es escribible.",
+        "en": "The configuration directory is not writable.",
+    },
+    "DOCTOR.CRITICAL.KEYRING_UNAVAILABLE": {
+        "es": "El backend de keyring no está disponible.",
+        "en": "The keyring backend is unavailable.",
+    },
 }
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -16,6 +16,16 @@ import pytest
 from nz_mcp import config
 
 
+class _TestKeyringBackend:
+    """Stub backend so ``nz_mcp doctor`` sees keyring as available in tests.
+
+    CI runners are often headless; the real default is often ``FailKeyring``, which would
+    make ``doctor`` exit 1 and break smoke tests unrelated to keyring behavior.
+    """
+
+    __slots__ = ()
+
+
 @pytest.fixture(autouse=True)
 def isolated_keyring(monkeypatch: pytest.MonkeyPatch) -> None:
     """Replace keyring globals with an in-memory store."""
@@ -30,9 +40,13 @@ def isolated_keyring(monkeypatch: pytest.MonkeyPatch) -> None:
     def _delete(service: str, username: str) -> None:
         store.pop((service, username), None)
 
+    def _get_keyring() -> _TestKeyringBackend:
+        return _TestKeyringBackend()
+
     monkeypatch.setattr(_keyring, "set_password", _set)
     monkeypatch.setattr(_keyring, "get_password", _get)
     monkeypatch.setattr(_keyring, "delete_password", _delete)
+    monkeypatch.setattr(_keyring, "get_keyring", _get_keyring)
 
 
 @pytest.fixture

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from pathlib import Path
 
+import pytest
 from typer.testing import CliRunner
 
 from nz_mcp import __version__
@@ -35,3 +36,27 @@ def test_serve_is_stub() -> None:
     result = runner.invoke(app, ["serve"])
     assert result.exit_code == 0
     assert "stub" in result.output
+
+
+def test_doctor_smoke_ok(two_profiles: Path) -> None:
+    result = runner.invoke(app, ["doctor"])
+    assert result.exit_code == 0
+    out = result.stdout.lower()
+    assert "nz-mcp" in out
+    assert "python" in out
+
+
+def _fail_keyring_backend() -> object:
+    from keyring.backends.fail import Keyring as FailKeyring
+
+    return FailKeyring()  # type: ignore[no-untyped-call]
+
+
+def test_doctor_exit_1_when_keyring_unavailable(
+    monkeypatch: pytest.MonkeyPatch, tmp_profiles: Path
+) -> None:
+    import keyring as kr
+
+    monkeypatch.setattr(kr, "get_keyring", _fail_keyring_backend)
+    result = runner.invoke(app, ["doctor"])
+    assert result.exit_code == 1

--- a/tests/unit/test_diagnostic.py
+++ b/tests/unit/test_diagnostic.py
@@ -1,0 +1,71 @@
+"""Unit tests for ``diagnostic.collect_diagnostic`` (no Netezza, no secrets in output)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import keyring
+import pytest
+from keyring.backends.fail import Keyring as FailKeyring
+
+from nz_mcp import __version__
+from nz_mcp.diagnostic import collect_diagnostic, format_diagnostic_report, report_json_for_audit
+
+
+def test_collect_happy_two_profiles(two_profiles: Path) -> None:
+    report = collect_diagnostic()
+    assert report.profiles_count == 2
+    assert set(report.profiles_names) == {"dev", "prod"}
+    assert report.active_profile == "dev"
+    assert report.profiles_load_ok is True
+    assert report.nz_mcp_version == __version__
+    assert report.locale in ("es", "en")
+    assert report.profiles_path_exists is True
+
+
+def test_collect_no_profiles(tmp_profiles: Path) -> None:
+    report = collect_diagnostic()
+    assert report.profiles_count == 0
+    assert report.profiles_names == ()
+    assert report.profiles_path_exists is False
+    assert report.active_profile is None
+
+
+def test_json_audit_excludes_sensitive_payload(two_profiles: Path) -> None:
+    """Profile TOML contains host/user — they must not appear in the diagnostic JSON."""
+    raw = report_json_for_audit(collect_diagnostic())
+    forbidden = (
+        "nz-dev.example.com",
+        "nz-prod.example.com",
+        "svc_dev",
+        "svc_prod",
+    )
+    for bad in forbidden:
+        assert bad not in raw, f"unexpected substring: {bad!r}"
+
+
+def _fail_keyring_backend() -> object:
+    return FailKeyring()  # type: ignore[no-untyped-call]
+
+
+def test_keyring_unavailable(monkeypatch: pytest.MonkeyPatch, tmp_profiles: Path) -> None:
+    monkeypatch.setattr(keyring, "get_keyring", _fail_keyring_backend)
+    report = collect_diagnostic()
+    assert report.keyring_available is False
+    assert report.is_healthy is False
+
+
+def test_invalid_profiles_toml(tmp_profiles: Path) -> None:
+    tmp_profiles.write_text("not valid {{{", encoding="utf-8")
+    report = collect_diagnostic()
+    assert report.profiles_load_ok is False
+
+
+def test_format_shows_critical_when_unhealthy(
+    monkeypatch: pytest.MonkeyPatch, tmp_profiles: Path
+) -> None:
+    monkeypatch.setattr(keyring, "get_keyring", _fail_keyring_backend)
+    report = collect_diagnostic()
+    text = format_diagnostic_report(report, locale="en")
+    assert "Critical issues" in text
+    assert "keyring" in text.lower()


### PR DESCRIPTION
﻿## Que cambia?
Se agrega `nz-mcp doctor` para diagnosticar el entorno local sin red ni conexion a Netezza, reduciendo tiempo de soporte y depuracion inicial. La implementacion separa recoleccion pura de datos y formateo CLI para mantener testabilidad y evitar filtrado de secretos.

## Issue relacionado
Closes #13

## Accion segun AGENTS.md
- **Ruta (keywords)**: `cli`, `i18n`, `tests`, `README`, `CHANGELOG`, `PR`
- **Docs leidos**:
  - `AGENTS.md`
  - `docs/standards/issue-workflow.md`
  - `docs/standards/git-workflow.md`
  - `docs/standards/pr-audit.md`
  - `docs/standards/coding.md`
  - `docs/standards/testing.md`
  - `docs/standards/i18n.md`
  - `docs/standards/maintainability.md`
  - `docs/roles/backend-developer.md`
  - `docs/roles/technical-writer.md`
- **Rol asumido**: Backend Developer + Technical Writer

## Archivos esperados (segun el issue)
- `src/nz_mcp/diagnostic.py` (nuevo)
- `src/nz_mcp/cli.py` (subcomando `doctor` + docstring)
- `src/nz_mcp/i18n.py` (claves nuevas ES/EN)
- `tests/unit/test_diagnostic.py` (nuevo)
- `tests/unit/test_cli.py` (extension)
- `README.md` (seccion Diagnostico)
- `README.en.md` (seccion Diagnostics)
- `CHANGELOG.md` (Unreleased -> Added)

Archivo extra tocado y justificacion:
- `tests/conftest.py`: se anade stub de `keyring.get_keyring()` para aislar tests del backend real en runners headless (Ubuntu CI usa `FailKeyring` por defecto). Sin este aislamiento, el smoke test de `doctor` falla por entorno y no por logica del comando.

## Auditoria pre-merge - 7 dimensiones
### 1. Contrato y compatibilidad
- [x] Si hay cambio observable: `CHANGELOG.md` con entrada bilingue en `Unreleased`.
- [x] Sin breaking change inesperado.

### 2. Seguridad
- [x] Sin credenciales en codigo, logs, tests, fixtures, comentarios.

### 3. Mantenibilidad y diseno
- [x] Toque solo los archivos esperados (o documente por que no).
- [x] Sin dependencias nuevas sin ADR.
- [x] Una intencion por PR.

### 4. Tests
- [x] Tests para todo comportamiento nuevo.
- [x] `pytest -m "not integration"` verde local.
- [x] Cobertura >= 85 % global.

### 5. Tipado y estilo
- [x] `ruff check .` y `ruff format --check .` limpios.
- [x] `mypy --strict` limpio en modulos tocados.

### 6. Documentacion
- [x] `CHANGELOG.md` actualizado (ES + EN).
- [x] Mensajes nuevos: claves anadidas en ES y EN.

### 7. Idioma y forma
- [x] Titulo de PR en espanol, formato conventional commit.
- [x] Branch cumple regex.
- [x] Commits en espanol, conventional.
- [x] Codigo y comentarios en ingles.

## Validacion humana requerida
- [x] Si - confirmar semantica final de severidad de `doctor` para `keyring` no disponible en entornos sin backend del sistema.
- [ ] No

## Notas para el auditor
- Pendiente post-merge sugerido: documentar `except Exception` defensivo en `_probe_keyring`.
- Pendiente post-merge sugerido: revisar dependencia de helper privado `_single_profile_or_none`.
