### PR TITLE
chore(ci): auto-claim de issues al abrir draft PR desde fork

### DIFF
--- a/.github/workflows/auto-claim.yml
+++ b/.github/workflows/auto-claim.yml
@@ -1,0 +1,111 @@
+name: Auto-claim issue
+
+# Aplica/quita `claimed` y assignee al issue referenciado por un PR.
+#
+# Uso `pull_request_target` (no `pull_request`) para que el token tenga
+# `issues: write` en el repo base aun cuando el PR viene de un fork.
+#
+# SEGURIDAD: **no hacer checkout del código del PR**. El workflow solo usa
+# `actions/github-script` con la API REST de GitHub. Cualquier cambio que
+# añada ejecución de código del fork es bloqueante y requiere ADR.
+
+on:
+  pull_request_target:
+    types: [opened, reopened, edited, closed]
+
+permissions:
+  issues: write
+  pull-requests: read
+
+jobs:
+  claim:
+    name: Apply or revoke claim
+    runs-on: ubuntu-latest
+    steps:
+      - name: Update claim label and assignee
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const pr = context.payload.pull_request;
+            const body = pr.body || "";
+            const actor = pr.user.login;
+            const isClosed = pr.state === "closed";
+            const wasMerged = pr.merged === true;
+
+            // Match `Closes|Fixes|Resolves #N` variants (case-insensitive).
+            const regex = /\b(?:closes|closed|close|fixes|fixed|fix|resolves|resolved|resolve)\s+#(\d+)\b/gi;
+            const issueNumbers = [
+              ...new Set([...body.matchAll(regex)].map((m) => parseInt(m[1], 10))),
+            ];
+
+            if (issueNumbers.length === 0) {
+              core.info("No issue references found in PR body. Nothing to do.");
+              return;
+            }
+
+            const { owner, repo } = context.repo;
+            core.info(
+              `PR #${pr.number} state=${pr.state} merged=${wasMerged} actor=${actor} ` +
+                `issues=[${issueNumbers.join(", ")}]`,
+            );
+
+            for (const issueNumber of issueNumbers) {
+              if (isClosed && !wasMerged) {
+                // Revoke claim: remove label + unassign (best-effort).
+                try {
+                  await github.rest.issues.removeLabel({
+                    owner,
+                    repo,
+                    issue_number: issueNumber,
+                    name: "claimed",
+                  });
+                  core.info(`Removed 'claimed' from #${issueNumber}`);
+                } catch (e) {
+                  core.info(
+                    `Could not remove 'claimed' from #${issueNumber} (benign): ${e.message}`,
+                  );
+                }
+                try {
+                  await github.rest.issues.removeAssignees({
+                    owner,
+                    repo,
+                    issue_number: issueNumber,
+                    assignees: [actor],
+                  });
+                  core.info(`Unassigned ${actor} from #${issueNumber}`);
+                } catch (e) {
+                  core.info(
+                    `Could not unassign ${actor} from #${issueNumber} (benign): ${e.message}`,
+                  );
+                }
+              } else if (!isClosed) {
+                // Apply claim: add label + assign (best-effort).
+                try {
+                  await github.rest.issues.addLabels({
+                    owner,
+                    repo,
+                    issue_number: issueNumber,
+                    labels: ["claimed"],
+                  });
+                  core.info(`Applied 'claimed' to #${issueNumber}`);
+                } catch (e) {
+                  core.info(
+                    `Could not apply 'claimed' to #${issueNumber} (benign): ${e.message}`,
+                  );
+                }
+                try {
+                  await github.rest.issues.addAssignees({
+                    owner,
+                    repo,
+                    issue_number: issueNumber,
+                    assignees: [actor],
+                  });
+                  core.info(`Assigned ${actor} to #${issueNumber}`);
+                } catch (e) {
+                  core.info(
+                    `Could not assign ${actor} to #${issueNumber} (benign): ${e.message}`,
+                  );
+                }
+              }
+              // If merged, GitHub auto-closes the issue; no label action needed.
+            }

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -35,6 +35,52 @@ pre-commit install --hook-type pre-push --hook-type commit-msg
 pytest -m "not integration"
 ```
 
+## Fork workflow for external contributors
+
+Si no tienes permisos de escritura en el repo (caso típico en OSS), el flujo es:
+
+```bash
+# 1. Fork y clone
+gh repo fork Oscarsp15/nz-mcp --clone=false
+gh repo clone <tu-usuario>/nz-mcp
+cd nz-mcp
+
+# 2. Vincular upstream para sincronizar main
+git remote add upstream https://github.com/Oscarsp15/nz-mcp.git
+
+# 3. Crear branch (nombre debe cumplir el regex de git-workflow.md §1)
+git checkout -b feat/<n>-<slug-en-kebab-case>
+
+# 4. Implementar, seguir AGENTS.md, tests, etc.
+pre-commit install --hook-type pre-push --hook-type commit-msg
+# ... edita código ...
+git commit -m "feat(<scope>): <descripción en imperativo>"
+
+# 5. Push al fork y abrir PR contra el upstream
+git push -u origin feat/<n>-<slug-en-kebab-case>
+gh pr create --repo Oscarsp15/nz-mcp --title "..." --body-file body.md
+```
+
+### Primera vez
+
+GitHub Actions pide al owner aprobar workflows manualmente la primera vez que un contributor externo dispara CI. El owner clickea **"Approve and run"** en la pestaña `Actions`. Tras eso, los siguientes pushes del mismo contributor corren automático.
+
+### Permisos en el repo base
+
+Contributors externos NO pueden:
+- Asignarse a issues, aplicar labels, ni mergear PRs.
+
+**No es un problema**: el workflow `auto-claim.yml` aplica el label `claimed` y el assignee automáticamente al abrir el draft PR con `Closes #N`. Ver [`docs/standards/issue-workflow.md`](docs/standards/issue-workflow.md) sección "Claim automático".
+
+### Sincronizar fork con upstream
+
+```bash
+git fetch upstream
+git checkout main
+git merge --ff-only upstream/main
+git push origin main
+```
+
 ## Idioma
 
 - **Código y comentarios**: inglés.

--- a/docs/standards/issue-workflow.md
+++ b/docs/standards/issue-workflow.md
@@ -69,20 +69,43 @@ Sincronizado por `.github/workflows/sync-labels.yml` desde `.github/labels.yml`.
 
 ## Protocolo de claim (para evitar dos IAs trabajando en lo mismo)
 
-**Reglas duras:**
+### Claim automático por bot (desde v0.1)
 
-1. Antes de empezar, comprobar que el issue **no tiene** label `claimed` ni assignee.
-2. Para "tomarlo":
-   - **Comentar** en el issue: `🤖 Tomando este issue. Sesión: <id-corto>. Crearé draft PR y volveré con link.`
-   - **Asignarse** vía `gh issue edit <n> --add-assignee @me` (o pedir al humano si la IA no tiene cuenta propia).
-   - **Añadir label** `claimed` vía `gh issue edit <n> --add-label claimed`.
-   - **Crear draft PR** con título `[WIP] <título issue>` y `Closes #<n>` en el cuerpo.
-3. **Renunciar** si descubres que el issue es más grande, ambiguo, o requiere `human-only`:
-   - Comentar `🤖 Renuncio: <razón>. Vuelvo a dejar el issue libre.`
-   - Quitar label `claimed`, quitar assignee, cerrar draft PR sin merge.
-4. **Timeout de claim**: si un `claimed` lleva > 7 días sin commit en su PR linkeado, otra IA puede reclamarlo (comentando primero).
+El **draft PR con `Closes #N`** ES el claim real. Un workflow (`.github/workflows/auto-claim.yml`) aplica en automático, al detectar el PR:
 
-**Detector de doble-trabajo**: workflow `claim-stale.yml` corre semanalmente y comenta los `claimed` sin actividad reciente.
+- Añade label `claimed` al issue.
+- Asigna al autor del PR al issue.
+
+Al cerrar el PR sin mergear, el bot **revoca** el claim (quita label + desasigna). Al mergear, GitHub cierra el issue por sí mismo.
+
+**Consecuencia práctica**: ningún contributor necesita permisos de `issues:write` para reclamar un issue. Los contributors externos desde fork solo abren el PR y el bot hace el resto.
+
+### Protocolo (aplica a todos, internos y externos)
+
+1. Antes de empezar, comprobar que el issue **no tiene** label `claimed` ni assignee. Si los tiene, alguien más está trabajando en él.
+2. **Crear draft PR** desde tu rama (o tu fork) con:
+   - Título en formato conventional (`<tipo>(<scope>): <descripción>`).
+   - **Cuerpo usando `.github/PULL_REQUEST_TEMPLATE.md` completo**, con `Closes #N` en la sección "Issue relacionado".
+3. (Opcional, recomendado) Comentar en el issue: `🤖 Tomando este issue. Sesión: <id-corto>. PR: #<pr-n>.` — aumenta trazabilidad pero el bot hace el claim igualmente.
+4. **Renunciar** si descubres que el issue es más grande, ambiguo o requiere `human-only`:
+   - Cierra el draft PR **sin merge**. El bot revoca el claim automáticamente.
+   - Comenta en el issue: `🤖 Renuncio: <razón>. Vuelvo a dejar el issue libre.`
+5. **Timeout de claim**: si un `claimed` lleva > 7 días sin commit en su PR linkeado, otra IA puede reclamarlo (comentando primero). Ver `.github/workflows/stale-claim.yml`.
+
+### Contributors externos desde fork (OSS típico)
+
+Contributors sin permisos de `issues:write` en el repo base:
+
+1. `gh repo fork Oscarsp15/nz-mcp` → trabaja en el fork.
+2. Rama con nombre cumpliendo regex de [`git-workflow.md`](git-workflow.md) §1.
+3. Push al fork; `gh pr create --repo Oscarsp15/nz-mcp` abre PR hacia `Oscarsp15:main`.
+4. Primera vez: el owner debe aprobar workflows manualmente en `Actions` (política `Require approval for first-time contributors`). Tras una aprobación, los siguientes pushes corren automático.
+5. El **auto-claim** aplica igual — no se requiere `issues:write` en el repo base.
+6. Tras merge: GitHub borra la rama del fork automáticamente (ya configurado con `delete_branch_on_merge=true`).
+
+Ver también `CONTRIBUTING.md` sección **"Fork workflow for external contributors"**.
+
+**Detector de doble-trabajo**: workflow `stale-claim.yml` corre semanalmente y comenta los `claimed` sin actividad reciente.
 
 ## Flujo extremo a extremo
 


### PR DESCRIPTION
## ¿Qué cambia?
Añade workflow `auto-claim.yml` que aplica/quita el label `claimed` y el assignee al issue referenciado por un PR, disparado por `pull_request_target` con `actions/github-script` — sin checkout del código del fork (patrón seguro de `pull_request_target`). Actualiza `issue-workflow.md` y `CONTRIBUTING.md` para documentar el nuevo flujo y clarificar el workflow de contributors externos desde fork.

Resuelve la fricción detectada durante el PR #20: contributors externos sin `issues:write` (lo normal en OSS) no podían aplicar `claimed` ni asignarse, requiriendo intervención manual del owner cada vez. Ahora el draft PR con `Closes #N` ES el claim real.

## Issue relacionado
Closes #21

## Acción según AGENTS.md
- **Ruta (keywords)**: `CI`, `GitHub Actions`, `issue`, `claim`
- **Docs leídos**:
  - `AGENTS.md`
  - `docs/standards/issue-workflow.md`
  - `docs/standards/pr-audit.md`
  - `docs/standards/git-workflow.md`
  - `docs/roles/release-engineer.md`
- **Rol asumido**: Release Engineer

## Archivos tocados
- `.github/workflows/auto-claim.yml` (nuevo, +95 LoC)
- `docs/standards/issue-workflow.md` (sección "Claim automático" añadida, protocolo relajado, sección "Contributors externos desde fork" añadida)
- `CONTRIBUTING.md` (nueva sección "Fork workflow for external contributors" con comandos + nota de permisos)

Todos esperados según el issue #21. Ningún archivo fuera de la lista.

## Auditoría pre-merge — 7 dimensiones

### 1. Contrato y compatibilidad
- [x] No toca `tools-contract.md`.
- [N/A] CHANGELOG — cambio interno de proceso, no observable al usuario del paquete.
- [x] Sin breaking.

### 2. Seguridad
- [x] `pull_request_target` + `github-script` sin checkout del fork (patrón seguro documentado en el propio YAML).
- [x] Permisos mínimos: `issues: write`, `pull-requests: read`.
- [x] Errores del API no bloquean el workflow (best-effort con try/catch — el claim es nice-to-have, no crítico).
- [N/A] No toca SQL, credenciales ni `sql_guard.py`.

### 3. Mantenibilidad y diseño
- [x] Solo 3 archivos tocados, todos esperados.
- [x] Sin abstracciones nuevas sin 3 usos reales.
- [x] Sin dependencias Python nuevas.
- [N/A] Funciones < 50 LoC — JS inline en workflow, diseño simple lineal.
- [x] Una intención por PR.
- [x] PR < 400 LoC sin contar docs (+95 de YAML, el resto es doc).

### 4. Tests
- [N/A] No aplica tests automatizados del workflow — validación se hace al siguiente PR externo que abra (el workflow corre y se ve el resultado en GitHub).
- [x] `pytest -m "not integration"` verde local (156 tests).
- [x] Cobertura sin regresión.
- [x] Sin skips.

### 5. Tipado y estilo
- [x] `ruff check .` y `ruff format --check .` limpios.
- [x] `mypy --strict` limpio (no toca Python).
- [x] `scripts/check_repo_hygiene.py` verde.
- [x] Sin `Any` en superficies públicas.

### 6. Documentación
- [x] `issue-workflow.md` actualizado con "Claim automático" + "Contributors externos desde fork".
- [x] `CONTRIBUTING.md` actualizado con sección "Fork workflow".
- [N/A] `tools-contract.md` — no toca tools.
- [N/A] `CHANGELOG.md` — cambio interno.
- [N/A] ADR — no es decisión arquitectónica nueva (resuelve gap operacional).
- [N/A] Mensajes i18n — no hay mensajes nuevos.

### 7. Idioma y forma
- [x] Título PR conventional en español, <72 chars.
- [x] Branch `chore/21-auto-claim-workflow` cumple regex (validado por CI).
- [x] Commit conventional en español.
- [x] Código y comentarios en inglés.

## Validación humana requerida
- [ ] No

## Notas para el auditor
- El workflow es **idempotente** por diseño: cada ejecución re-aplica (o re-revoca) el estado correcto según el payload del PR. Si un issue queda desincronizado, el próximo `edited` o `reopened` lo corrige.
- Intencionalmente **NO** añado el workflow como required status check. El claim es nice-to-have, no bloqueante: si el bot falla, el owner aún puede aplicar labels manualmente (como hizo en #17). Mantener el workflow fuera del critical path evita cascadas de fallos de CI por el bot.
- Validación real del workflow: se observa en el siguiente PR externo que abra un contributor (ej. cuando x1Manulml tome #16 o #18). El label y assignee deben aparecer automáticamente en el issue referenciado.
- Tras merge, no hay cambios a branch protection. El ADR 0008 (`required_reviews=0`) sigue aplicando.
