### PR TITLE
refactor(catalog): centraliza queries en queries.py con struct CatalogQuery

### DIFF
--- a/docs/architecture/netezza-catalog-queries.md
+++ b/docs/architecture/netezza-catalog-queries.md
@@ -4,6 +4,9 @@ Este documento es la fuente de verdad única para el SQL de catálogo usado por
 `nz-mcp`. Resume el comportamiento validado contra IBM Netezza Performance
 Server y reemplaza supuestos de borradores iniciales.
 
+Nota: las queries ahora viven en `src/nz_mcp/catalog/queries.py`. Este documento
+es la fuente de verdad humana; el módulo es la fuente de verdad de código.
+
 ## Alcance
 
 - Vistas de catálogo y SQL usados por las tools MCP.

--- a/src/nz_mcp/catalog/databases.py
+++ b/src/nz_mcp/catalog/databases.py
@@ -6,13 +6,11 @@ from contextlib import closing
 from typing import Any, Final, Protocol, cast
 
 from nz_mcp.auth import get_password
+from nz_mcp.catalog.queries import LIST_DATABASES
 from nz_mcp.config import Profile
 from nz_mcp.connection import open_connection
 from nz_mcp.errors import NetezzaError
 
-_LIST_DATABASES_SQL = (
-    "SELECT DATABASE, OWNER FROM _v_database WHERE (? IS NULL OR DATABASE LIKE ?) ORDER BY DATABASE"
-)
 _DATABASE_ROW_MIN_ITEMS: Final[int] = 2
 
 
@@ -36,7 +34,7 @@ def list_databases(profile: Profile, pattern: str | None = None) -> list[dict[st
     connection = cast(_ConnectionLike, open_connection(profile, password))
     try:
         with closing(connection.cursor()) as cursor:
-            cursor.execute(_LIST_DATABASES_SQL, params)
+            cursor.execute(LIST_DATABASES.sql, params)
             rows = cursor.fetchall()
     except Exception as exc:
         raise NetezzaError(

--- a/src/nz_mcp/catalog/queries.py
+++ b/src/nz_mcp/catalog/queries.py
@@ -1,0 +1,197 @@
+"""Central catalog query registry."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Final
+
+NPS_112_IF1: Final[str] = "NPS 11.2.1.11-IF1"
+
+
+@dataclass(frozen=True, slots=True)
+class CatalogQuery:
+    id: str
+    sql: str
+    catalog_views: tuple[str, ...]
+    description: str
+    tested_versions: tuple[str, ...] = ()
+    cross_database: bool = False
+
+
+LIST_DATABASES: Final[CatalogQuery] = CatalogQuery(
+    id="list_databases",
+    sql=(
+        "SELECT DATABASE, OWNER FROM _v_database "
+        "WHERE (? IS NULL OR DATABASE LIKE ?) ORDER BY DATABASE"
+    ),
+    catalog_views=("_V_DATABASE",),
+    description="Lists visible databases with an optional LIKE filter.",
+    tested_versions=(NPS_112_IF1,),
+)
+
+LIST_SCHEMAS: Final[CatalogQuery] = CatalogQuery(
+    id="list_schemas",
+    sql=(
+        "SELECT SCHEMA, OWNER FROM <BD>.._V_SCHEMA "
+        "WHERE (? IS NULL OR SCHEMA LIKE ?) ORDER BY SCHEMA"
+    ),
+    catalog_views=("_V_SCHEMA",),
+    description="Lists schemas for a specific database using cross-database notation.",
+    tested_versions=(NPS_112_IF1,),
+    cross_database=True,
+)
+
+LIST_TABLES: Final[CatalogQuery] = CatalogQuery(
+    id="list_tables",
+    sql=(
+        "SELECT TABLENAME AS NAME, OWNER FROM <BD>.._V_TABLE "
+        "WHERE SCHEMA = UPPER(?) AND OBJTYPE='TABLE' "
+        "AND (? IS NULL OR TABLENAME LIKE ?) ORDER BY TABLENAME"
+    ),
+    catalog_views=("_V_TABLE",),
+    description="Lists tables for a schema with optional name filter.",
+    tested_versions=(NPS_112_IF1,),
+    cross_database=True,
+)
+
+LIST_VIEWS: Final[CatalogQuery] = CatalogQuery(
+    id="list_views",
+    sql=(
+        "SELECT VIEWNAME AS NAME, OWNER, CREATEDATE FROM <BD>.._V_VIEW "
+        "WHERE SCHEMA = UPPER(?) AND (? IS NULL OR VIEWNAME LIKE ?) ORDER BY VIEWNAME"
+    ),
+    catalog_views=("_V_VIEW",),
+    description="Lists views for a schema with optional name filter.",
+    tested_versions=(NPS_112_IF1,),
+    cross_database=True,
+)
+
+GET_VIEW_DDL: Final[CatalogQuery] = CatalogQuery(
+    id="get_view_ddl",
+    sql="SELECT DEFINITION FROM <BD>.._V_VIEW WHERE SCHEMA = UPPER(?) AND VIEWNAME = UPPER(?)",
+    catalog_views=("_V_VIEW",),
+    description="Returns CREATE VIEW definition text.",
+    tested_versions=(NPS_112_IF1,),
+    cross_database=True,
+)
+
+DESCRIBE_TABLE_COLUMNS: Final[CatalogQuery] = CatalogQuery(
+    id="describe_table_columns",
+    sql=(
+        "SELECT ATTNAME AS COLUMN_NAME, FORMAT_TYPE AS DATA_TYPE, "
+        "ATTNOTNULL AS NOT_NULL, COLDEFAULT AS DEFAULT_VALUE, ATTNUM "
+        "FROM <BD>.._V_RELATION_COLUMN "
+        "WHERE SCHEMA = UPPER(?) AND NAME = UPPER(?) ORDER BY ATTNUM"
+    ),
+    catalog_views=("_V_RELATION_COLUMN",),
+    description="Returns table column metadata in ordinal order.",
+    tested_versions=(NPS_112_IF1,),
+    cross_database=True,
+)
+
+DESCRIBE_TABLE_DISTRIBUTION: Final[CatalogQuery] = CatalogQuery(
+    id="describe_table_distribution",
+    sql=(
+        "SELECT ATTNAME, DISTSEQNO FROM <BD>.._V_TABLE_DIST_MAP "
+        "WHERE SCHEMA = UPPER(?) AND TABLENAME = UPPER(?) ORDER BY DISTSEQNO"
+    ),
+    catalog_views=("_V_TABLE_DIST_MAP",),
+    description="Returns distribution keys used to infer HASH vs RANDOM.",
+    tested_versions=(NPS_112_IF1,),
+    cross_database=True,
+)
+
+DESCRIBE_TABLE_PK: Final[CatalogQuery] = CatalogQuery(
+    id="describe_table_pk",
+    sql=(
+        "SELECT CONSTRAINTNAME, ATTNAME, CONSEQ FROM <BD>.._V_RELATION_KEYDATA "
+        "WHERE SCHEMA = UPPER(?) AND RELATION = UPPER(?) AND CONTYPE = 'p' "
+        "ORDER BY CONSEQ"
+    ),
+    catalog_views=("_V_RELATION_KEYDATA",),
+    description="Returns primary key columns in key order.",
+    tested_versions=(NPS_112_IF1,),
+    cross_database=True,
+)
+
+DESCRIBE_TABLE_FK: Final[CatalogQuery] = CatalogQuery(
+    id="describe_table_fk",
+    sql=(
+        "SELECT CONSTRAINTNAME, ATTNAME, CONSEQ, PKDATABASE, PKSCHEMA, PKRELATION, "
+        "PKATTNAME, DEL_TYPE, UPDT_TYPE FROM <BD>.._V_RELATION_KEYDATA "
+        "WHERE SCHEMA = UPPER(?) AND RELATION = UPPER(?) AND CONTYPE = 'f' "
+        "ORDER BY CONSTRAINTNAME, CONSEQ"
+    ),
+    catalog_views=("_V_RELATION_KEYDATA",),
+    description="Returns foreign keys and referenced columns.",
+    tested_versions=(NPS_112_IF1,),
+    cross_database=True,
+)
+
+TABLE_STATS: Final[CatalogQuery] = CatalogQuery(
+    id="table_stats",
+    sql=(
+        "SELECT t.RELTUPLES AS ROW_COUNT, ts.USED_BYTES AS SIZE_BYTES_USED, "
+        "ts.ALLOCATED_BYTES AS SIZE_BYTES_ALLOCATED, ts.SKEW, "
+        "t.CREATEDATE AS TABLE_CREATED FROM <BD>.._V_TABLE t "
+        "JOIN <BD>.._V_TABLE_STORAGE_STAT ts ON t.OBJID = ts.OBJID "
+        "WHERE t.SCHEMA = UPPER(?) AND t.TABLENAME = UPPER(?)"
+    ),
+    catalog_views=("_V_TABLE", "_V_TABLE_STORAGE_STAT"),
+    description="Returns row estimate and storage metrics for one table.",
+    tested_versions=(NPS_112_IF1,),
+    cross_database=True,
+)
+
+LIST_PROCEDURES: Final[CatalogQuery] = CatalogQuery(
+    id="list_procedures",
+    sql=(
+        "SELECT PROCEDURE, OWNER, ARGUMENTS, RETURNS, PROCEDURESIGNATURE, NUMARGS "
+        "FROM <BD>.._V_PROCEDURE WHERE SCHEMA = UPPER(?) "
+        "AND (? IS NULL OR PROCEDURE LIKE ?) ORDER BY PROCEDURE"
+    ),
+    catalog_views=("_V_PROCEDURE",),
+    description="Lists procedures for a schema with optional name filter.",
+    tested_versions=(NPS_112_IF1,),
+    cross_database=True,
+)
+
+GET_PROCEDURE_DDL: Final[CatalogQuery] = CatalogQuery(
+    id="get_procedure_ddl",
+    sql=(
+        "SELECT PROCEDURE, ARGUMENTS, RETURNS, PROCEDURESOURCE, PROCEDURESIGNATURE "
+        "FROM <BD>.._V_PROCEDURE WHERE SCHEMA = UPPER(?) AND PROCEDURE = UPPER(?)"
+    ),
+    catalog_views=("_V_PROCEDURE",),
+    description="Returns procedure source and signature metadata.",
+    tested_versions=(NPS_112_IF1,),
+    cross_database=True,
+)
+
+GET_PROCEDURE_SECTION: Final[CatalogQuery] = CatalogQuery(
+    id="get_procedure_section",
+    sql=(
+        "SELECT PROCEDURE, ARGUMENTS, RETURNS, PROCEDURESOURCE, PROCEDURESIGNATURE "
+        "FROM <BD>.._V_PROCEDURE WHERE SCHEMA = UPPER(?) AND PROCEDURE = UPPER(?)"
+    ),
+    catalog_views=("_V_PROCEDURE",),
+    description="Returns procedure source used for section extraction.",
+    tested_versions=(NPS_112_IF1,),
+    cross_database=True,
+)
+
+ALL_QUERIES: Final[tuple[CatalogQuery, ...]] = (
+    LIST_DATABASES,
+    LIST_SCHEMAS,
+    LIST_TABLES,
+    LIST_VIEWS,
+    GET_VIEW_DDL,
+    DESCRIBE_TABLE_COLUMNS,
+    DESCRIBE_TABLE_DISTRIBUTION,
+    DESCRIBE_TABLE_PK,
+    DESCRIBE_TABLE_FK,
+    TABLE_STATS,
+    LIST_PROCEDURES,
+    GET_PROCEDURE_DDL,
+    GET_PROCEDURE_SECTION,
+)

--- a/tests/unit/test_catalog_queries.py
+++ b/tests/unit/test_catalog_queries.py
@@ -1,0 +1,48 @@
+"""Tests for centralized catalog query registry."""
+
+from __future__ import annotations
+
+from nz_mcp.catalog import queries
+
+
+def test_all_queries_contains_all_exported_query_constants() -> None:
+    constants = [
+        queries.LIST_DATABASES,
+        queries.LIST_SCHEMAS,
+        queries.LIST_TABLES,
+        queries.LIST_VIEWS,
+        queries.GET_VIEW_DDL,
+        queries.DESCRIBE_TABLE_COLUMNS,
+        queries.DESCRIBE_TABLE_DISTRIBUTION,
+        queries.DESCRIBE_TABLE_PK,
+        queries.DESCRIBE_TABLE_FK,
+        queries.TABLE_STATS,
+        queries.LIST_PROCEDURES,
+        queries.GET_PROCEDURE_DDL,
+        queries.GET_PROCEDURE_SECTION,
+    ]
+
+    assert set(queries.ALL_QUERIES) == set(constants)
+
+
+def test_query_ids_are_unique() -> None:
+    ids = [query.id for query in queries.ALL_QUERIES]
+    assert len(ids) == len(set(ids))
+
+
+def test_catalog_views_use_v_prefix() -> None:
+    for query in queries.ALL_QUERIES:
+        assert query.catalog_views
+        for catalog_view in query.catalog_views:
+            assert catalog_view.startswith("_V_")
+
+
+def test_cross_database_flag_matches_sql_marker() -> None:
+    for query in queries.ALL_QUERIES:
+        has_marker = "<BD>.." in query.sql
+        assert query.cross_database is has_marker
+
+
+def test_all_queries_are_marked_with_tested_version() -> None:
+    for query in queries.ALL_QUERIES:
+        assert query.tested_versions == ("NPS 11.2.1.11-IF1",)


### PR DESCRIPTION
﻿## ¿Qué cambia?
Centraliza las queries de catálogo en un módulo tipado (`src/nz_mcp/catalog/queries.py`) con metadatos estables por query y refactoriza `catalog/databases.py` para consumir `LIST_DATABASES` sin alterar comportamiento observable. Añade tests de invariantes del registro central y deja documentada la dualidad fuente-humana/fuente-código en arquitectura.

## Issue relacionado
Closes #28

## Acción según AGENTS.md
- **Ruta (keywords)**: `refactor`, `catálogo`, `mantenibilidad`
- **Docs leídos**:
  - `docs/architecture/netezza-catalog-queries.md`
  - `docs/roles/data-engineer.md`
  - `docs/roles/backend-developer.md`
  - `docs/standards/maintainability.md`
  - `docs/standards/pr-audit.md`
  - `docs/standards/coding.md`
  - `docs/standards/issue-workflow.md`
  - `docs/standards/git-workflow.md`
- **Rol asumido**: Backend Developer + Data Engineer

## Archivos esperados (según el issue)
- `src/nz_mcp/catalog/queries.py` ✅ (nuevo)
- `src/nz_mcp/catalog/databases.py` ✅ (consume `queries.LIST_DATABASES`)
- `tests/unit/test_catalog_queries.py` ✅ (nuevo)
- `docs/architecture/netezza-catalog-queries.md` ✅ (nota añadida sobre fuente de verdad de código)

## Auditoría pre-merge — 7 dimensiones
> Marca todas las casillas. Bloqueantes sin marcar = no merge.
> Detalle: docs/standards/pr-audit.md

### 1. Contrato y compatibilidad
- [ ] Si toca tools: `docs/architecture/tools-contract.md` actualizado en este PR. [N/A: no cambia tools públicas]
- [ ] Si hay cambio observable: `CHANGELOG.md` con entrada bilingüe en `Unreleased`. [N/A: refactor interno no observable]
- [x] Sin breaking change inesperado.

### 2. Seguridad
- [x] Todo SQL pasa por `sql_guard.validate()`.
- [x] Sin SQL concatenado (parametrizado).
- [x] Sin credenciales en código, logs, tests, fixtures, comentarios.
- [ ] Si toca `sql_guard.py` o `auth.py`: cobertura sigue en 100 %. [N/A: no se tocan]
- [ ] Si toca `sql_guard.py`: ≥ 3 tests adversariales nuevos. [N/A: no se toca]

### 3. Mantenibilidad y diseño
- [x] Toqué solo los archivos esperados (o documenté por qué no).
- [x] Sin abstracciones nuevas sin 3 usos reales.
- [x] Sin dependencias nuevas sin ADR.
- [x] Funciones < 50 LoC, args < 4.
- [x] Una intención por PR.
- [x] PR < 400 LoC sin tests/docs (o justificado).

### 4. Tests
- [x] Tests para todo comportamiento nuevo.
- [x] `pytest -m "not integration"` verde local.
- [x] Cobertura ≥ 85 % global, no cae respecto a `main`.
- [x] Sin `pytest.skip()` ni `xfail` sin issue.

### 5. Tipado y estilo
- [x] `ruff check .` y `ruff format --check .` limpios.
- [x] `mypy --strict` limpio en módulos tocados.
- [x] Sin `Any` en superficies públicas sin justificación.
- [x] Sin `except Exception:` sin re-raise tipado.

### 6. Documentación
- [ ] Si cambia API pública: `tools-contract.md` actualizado. [N/A: no cambia API]
- [ ] Si cambia comportamiento: `CHANGELOG.md` actualizado (ES + EN). [N/A: no cambia comportamiento]
- [ ] Si introduce decisión arquitectónica: nuevo ADR en `docs/adr/`. [N/A: refactor local]
- [ ] Mensajes nuevos: claves añadidas en ES **y** EN. [N/A: no hay i18n nuevo]

### 7. Idioma y forma
- [x] Título de PR en español, formato conventional commit.
- [x] Branch cumple regex (validado por CI).
- [x] Commits en español, conventional (validados por CI).
- [x] Código y comentarios en inglés.

## Validación humana requerida
- [ ] Sí — explicar por qué:
- [x] No

## Notas para el auditor
- Invariantes preservadas: tests existentes (`test_catalog_databases.py`, `test_tools_list_databases.py`) se ejecutaron sin modificación y pasaron.
- `ALL_QUERIES` incluye todas las constantes exportadas y cada entrada marca `tested_versions=("NPS 11.2.1.11-IF1",)`.
- El flag `cross_database` está validado por test contra presencia literal de `<BD>..` en SQL.
