### PR TITLE
feat(cli): añadir comando probe-catalog para validar catálogo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ Cada entrada se documenta en **español** y **english**.
 ## [Unreleased]
 
 ### Added
+- ES: comando CLI `nz-mcp probe-catalog` para validar todas las consultas de catálogo contra Netezza (parámetros dummy, duración, filas; salida `--json` opcional).
+- EN: `nz-mcp probe-catalog` CLI to validate all catalog queries against Netezza (dummy parameters, duration, rows; optional `--json` output).
 - ES: soporte `catalog_overrides` por perfil para resolver SQL de catálogo por `query_id` desde `profiles.toml`.
 - EN: added per-profile `catalog_overrides` to resolve catalog SQL by `query_id` from `profiles.toml`.
 - ES: módulo `catalog/resolver.py` con validación de `query_id` desconocido y warning para uso de `<BD>..` en queries no cross-db.

--- a/README.en.md
+++ b/README.en.md
@@ -70,6 +70,18 @@ Active profile: dev
 
 Exit code: `0` when the setup is OK; `1` on a critical issue (e.g. keyring unavailable).
 
+### Catalog diagnostics
+
+After you configure a profile and store the password in the OS keyring, you can verify that **every catalog query** (including `catalog_overrides` in `profiles.toml`) runs against your Netezza with safe dummy parameters:
+
+```bash
+nz-mcp probe-catalog
+nz-mcp probe-catalog --profile my_profile
+nz-mcp probe-catalog --json
+```
+
+The command reports duration and row counts per query. If a query only fails because a dummy table or object does not exist, it is reported as a warning rather than a hard failure. Exit code: `0` when there are no hard failures, `1` when any query fails definitively or the connection cannot be established.
+
 ## Available tools (24)
 
 Full contract: [`docs/architecture/tools-contract.md`](docs/architecture/tools-contract.md).

--- a/README.md
+++ b/README.md
@@ -70,6 +70,18 @@ Perfil activo: dev
 
 Código de salida: `0` si el entorno es usable; `1` si hay un problema crítico (p. ej. keyring no disponible).
 
+### Diagnóstico de catálogo
+
+Tras configurar un perfil y guardar la contraseña en el keyring, puedes validar que **todas las consultas del catálogo** (incluidas las de `catalog_overrides` en `profiles.toml`) se ejecutan contra tu Netezza con parámetros dummy seguros:
+
+```bash
+nz-mcp probe-catalog
+nz-mcp probe-catalog --profile mi_perfil
+nz-mcp probe-catalog --json
+```
+
+Mide duración y filas devueltas por query; si una consulta solo falla porque no existe un objeto de prueba (p. ej. tabla ficticia), se marca como advertencia, no como fallo duro. Código de salida: `0` si no hay errores graves, `1` si alguna query falla de forma definitiva o no se puede conectar.
+
 ## Tools disponibles (24)
 
 Ver el contrato completo en [`docs/architecture/tools-contract.md`](docs/architecture/tools-contract.md).

--- a/src/nz_mcp/catalog/probe.py
+++ b/src/nz_mcp/catalog/probe.py
@@ -1,0 +1,233 @@
+"""Validate catalog SQL for a profile by executing each registered query with dummy parameters."""
+
+from __future__ import annotations
+
+import time
+from contextlib import closing
+from dataclasses import dataclass
+from typing import Any, Final, Literal, cast
+
+from nz_mcp.auth import get_password
+from nz_mcp.catalog.identifier import render_cross_db
+from nz_mcp.catalog.queries import ALL_QUERIES, CatalogQuery
+from nz_mcp.catalog.resolver import resolve_query
+from nz_mcp.config import Profile
+from nz_mcp.connection import open_connection
+from nz_mcp.errors import ConnectionError as NzConnectionError
+from nz_mcp.errors import CredentialNotFoundError, InvalidInputError, InvalidProfileError
+
+_DUMMY_SCHEMA: Final[str] = "DBO"
+_DUMMY_OBJECT: Final[str] = "__NZ_MCP_PROBE_DUMMY__"
+
+# Queries whose dummy names may not exist; driver errors suggesting a missing object are warnings.
+_STRUCTURAL_IDS: Final[frozenset[str]] = frozenset(
+    {
+        "get_view_ddl",
+        "describe_table_columns",
+        "describe_table_distribution",
+        "describe_table_pk",
+        "describe_table_fk",
+        "table_stats",
+        "get_procedure_ddl",
+        "get_procedure_section",
+    }
+)
+
+
+ProbeStatus = Literal["ok", "failure", "structural_warning"]
+
+
+@dataclass(frozen=True, slots=True)
+class ProbeResult:
+    """Outcome for a single catalog query id."""
+
+    query_id: str
+    status: ProbeStatus
+    duration_ms: float | None
+    row_count: int | None
+    error_detail: str | None
+    detail: str | None  # human hint (e.g. placeholder mismatch)
+
+
+@dataclass(frozen=True, slots=True)
+class ProbeRun:
+    """Full probe result; ``config_error`` is set when the run could not finish normally."""
+
+    profile_name: str
+    config_error: str | None
+    results: tuple[ProbeResult, ...]
+
+
+def dummy_params_for_query_id(query_id: str) -> tuple[Any, ...]:
+    """Return safe dummy parameters matching the default SQL for ``query_id``."""
+    mapping: dict[str, tuple[Any, ...]] = {
+        "list_databases": (None, None),
+        "list_schemas": (None, None),
+        "list_tables": (_DUMMY_SCHEMA, None, None),
+        "list_views": (_DUMMY_SCHEMA, None, None),
+        "get_view_ddl": (_DUMMY_SCHEMA, _DUMMY_OBJECT),
+        "describe_table_columns": (_DUMMY_SCHEMA, _DUMMY_OBJECT),
+        "describe_table_distribution": (_DUMMY_SCHEMA, _DUMMY_OBJECT),
+        "describe_table_pk": (_DUMMY_SCHEMA, _DUMMY_OBJECT),
+        "describe_table_fk": (_DUMMY_SCHEMA, _DUMMY_OBJECT),
+        "table_stats": (_DUMMY_SCHEMA, _DUMMY_OBJECT),
+        "list_procedures": (_DUMMY_SCHEMA, None, None),
+        "get_procedure_ddl": (_DUMMY_SCHEMA, _DUMMY_OBJECT),
+        "get_procedure_section": (_DUMMY_SCHEMA, _DUMMY_OBJECT),
+    }
+    if query_id not in mapping:
+        raise KeyError(f"Unknown catalog query id: {query_id}")
+    return mapping[query_id]
+
+
+def _placeholder_mismatch_message(sql: str, params: tuple[Any, ...]) -> str | None:
+    n_q = sql.count("?")
+    if n_q != len(params):
+        return (
+            f"Placeholder count mismatch: SQL has {n_q} '?' "
+            f"but {len(params)} parameters were provided."
+        )
+    return None
+
+
+def _looks_like_missing_object(message: str) -> bool:
+    lowered = message.lower()
+    needles = (
+        "does not exist",
+        "not exist",
+        "not found",
+        "no such",
+        "undefined object",
+        "undefined name",
+        "object not found",
+    )
+    return any(n in lowered for n in needles)
+
+
+def prepare_sql(profile: Profile, cq: CatalogQuery) -> str:
+    """Resolve and render catalog SQL (``<BD>..``) for ``cq``."""
+    base = resolve_query(cq.id, profile)
+    return render_cross_db(base, profile.database)
+
+
+def probe_one_row(
+    cursor: Any,
+    profile: Profile,
+    cq: CatalogQuery,
+) -> ProbeResult:
+    """Execute one catalog probe using an open cursor."""
+    try:
+        sql = prepare_sql(profile, cq)
+    except (InvalidProfileError, InvalidInputError) as exc:
+        return ProbeResult(
+            query_id=cq.id,
+            status="failure",
+            duration_ms=None,
+            row_count=None,
+            error_detail=str(exc),
+            detail=None,
+        )
+
+    params = dummy_params_for_query_id(cq.id)
+    mismatch = _placeholder_mismatch_message(sql, params)
+    if mismatch is not None:
+        return ProbeResult(
+            query_id=cq.id,
+            status="failure",
+            duration_ms=None,
+            row_count=None,
+            error_detail=None,
+            detail=mismatch,
+        )
+
+    start = time.perf_counter()
+    try:
+        cursor.execute(sql, params)
+        rows = cursor.fetchall()
+    except Exception as exc:
+        duration_ms = (time.perf_counter() - start) * 1000.0
+        detail_text = str(exc)
+        if cq.id in _STRUCTURAL_IDS and _looks_like_missing_object(detail_text):
+            return ProbeResult(
+                query_id=cq.id,
+                status="structural_warning",
+                duration_ms=duration_ms,
+                row_count=None,
+                error_detail=detail_text,
+                detail=None,
+            )
+        return ProbeResult(
+            query_id=cq.id,
+            status="failure",
+            duration_ms=duration_ms,
+            row_count=None,
+            error_detail=detail_text,
+            detail=None,
+        )
+
+    duration_ms = (time.perf_counter() - start) * 1000.0
+    return ProbeResult(
+        query_id=cq.id,
+        status="ok",
+        duration_ms=duration_ms,
+        row_count=len(rows),
+        error_detail=None,
+        detail=None,
+    )
+
+
+def run_probe_catalog(profile: Profile) -> ProbeRun:
+    """Run all catalog probes for ``profile`` using a real Netezza connection."""
+    try:
+        resolve_query(ALL_QUERIES[0].id, profile)
+    except InvalidProfileError as exc:
+        return ProbeRun(profile_name=profile.name, config_error=str(exc), results=())
+
+    try:
+        password = get_password(profile.name)
+    except CredentialNotFoundError as exc:
+        return ProbeRun(profile_name=profile.name, config_error=str(exc), results=())
+
+    try:
+        connection = cast(Any, open_connection(profile, password))
+    except NzConnectionError as exc:
+        return ProbeRun(profile_name=profile.name, config_error=str(exc), results=())
+
+    results: list[ProbeResult] = []
+    try:
+        with closing(connection.cursor()) as cursor:
+            cur = cast(Any, cursor)
+            for cq in ALL_QUERIES:
+                results.append(probe_one_row(cur, profile, cq))
+    finally:
+        connection.close()
+
+    return ProbeRun(profile_name=profile.name, config_error=None, results=tuple(results))
+
+
+def probe_has_hard_failure(run: ProbeRun) -> bool:
+    """True if the run must yield a non-zero CLI exit (config error or any failure row)."""
+    if run.config_error is not None:
+        return True
+    return any(r.status == "failure" for r in run.results)
+
+
+def probe_result_to_json_dict(r: ProbeResult) -> dict[str, Any]:
+    """Serialize ``ProbeResult`` for JSON output."""
+    return {
+        "query_id": r.query_id,
+        "status": r.status,
+        "duration_ms": r.duration_ms,
+        "row_count": r.row_count,
+        "error": r.error_detail,
+        "detail": r.detail,
+    }
+
+
+def probe_run_to_json_dict(run: ProbeRun) -> dict[str, Any]:
+    """Serialize ``ProbeRun`` for JSON output."""
+    return {
+        "profile": run.profile_name,
+        "config_error": run.config_error,
+        "results": [probe_result_to_json_dict(r) for r in run.results],
+    }

--- a/src/nz_mcp/cli.py
+++ b/src/nz_mcp/cli.py
@@ -5,6 +5,7 @@ Commands:
 - ``add-profile``        add another profile.
 - ``list-profiles``      list configured profiles.
 - ``doctor``             print local diagnostics (no Netezza connection).
+- ``probe-catalog``      execute every catalog query with dummy parameters (validates overrides).
 - ``test-connection``    verify the active profile (stubbed in v0.1.0a0).
 - ``serve``              run the MCP server over stdio.
 - ``version``            print the package version.
@@ -13,6 +14,7 @@ Commands:
 from __future__ import annotations
 
 import contextlib
+import json
 from pathlib import Path
 from typing import cast
 
@@ -20,16 +22,20 @@ import typer
 
 from nz_mcp import __version__
 from nz_mcp.auth import store_password
+from nz_mcp.catalog.probe import probe_has_hard_failure, probe_run_to_json_dict, run_probe_catalog
 from nz_mcp.config import (
     DEFAULT_MAX_ROWS,
     DEFAULT_TIMEOUT_S,
     PermissionMode,
     config_dir,
+    get_active_profile,
+    get_profile,
     list_profile_names,
     profiles_path,
 )
 from nz_mcp.diagnostic import collect_diagnostic, format_diagnostic_report
-from nz_mcp.i18n import resolve_locale
+from nz_mcp.errors import InvalidProfileError, ProfileNotFoundError
+from nz_mcp.i18n import resolve_locale, t
 from nz_mcp.server import run_stdio_server
 
 app = typer.Typer(
@@ -82,6 +88,68 @@ def doctor_cmd() -> None:
     locale = resolve_locale()
     typer.echo(format_diagnostic_report(report, locale=locale))
     raise typer.Exit(code=0 if report.is_healthy else 1)
+
+
+@app.command("probe-catalog")
+def probe_catalog_cmd(
+    profile: str | None = typer.Option(
+        None,
+        "--profile",
+        "-p",
+        help="Profile name (default: active)",
+    ),
+    as_json: bool = typer.Option(False, "--json", help="Print machine-readable JSON"),
+) -> None:
+    """Run every registered catalog query with dummy parameters against Netezza."""
+    locale = resolve_locale()
+    try:
+        prof = get_profile(profile) if profile is not None else get_active_profile()
+    except ProfileNotFoundError as exc:
+        typer.secho(t("PROFILE_NOT_FOUND", locale, profile=exc.context["profile"]), err=True)
+        raise typer.Exit(code=1) from exc
+    except InvalidProfileError as exc:
+        typer.secho(t("INVALID_CONFIG", locale, detail=str(exc)), err=True)
+        raise typer.Exit(code=1) from exc
+
+    run = run_probe_catalog(prof)
+    if as_json:
+        typer.echo(json.dumps(probe_run_to_json_dict(run), indent=2, ensure_ascii=False))
+    else:
+        typer.secho(t("PROBE_CATALOG.HEADER", locale, profile=run.profile_name), bold=True)
+        if run.config_error is not None:
+            typer.secho(
+                t("PROBE_CATALOG.CONFIG_ERROR", locale, detail=run.config_error),
+                fg=typer.colors.RED,
+                err=True,
+            )
+        for row in run.results:
+            if row.status == "ok":
+                ms = row.duration_ms if row.duration_ms is not None else 0.0
+                rc = row.row_count if row.row_count is not None else 0
+                typer.echo(
+                    t("PROBE_CATALOG.LINE_OK", locale, query_id=row.query_id, ms=ms, rows=rc),
+                )
+            elif row.status == "structural_warning":
+                detail = row.error_detail or ""
+                typer.secho(
+                    t("PROBE_CATALOG.LINE_WARN", locale, query_id=row.query_id, detail=detail),
+                    fg=typer.colors.YELLOW,
+                )
+            else:
+                parts = []
+                if row.detail:
+                    parts.append(row.detail)
+                if row.error_detail:
+                    parts.append(row.error_detail)
+                detail = " — ".join(parts) if parts else "error"
+                typer.secho(
+                    t("PROBE_CATALOG.LINE_FAIL", locale, query_id=row.query_id, detail=detail),
+                    fg=typer.colors.RED,
+                    err=True,
+                )
+
+    code = 0 if not probe_has_hard_failure(run) else 1
+    raise typer.Exit(code=code)
 
 
 @app.command("test-connection")

--- a/src/nz_mcp/i18n.py
+++ b/src/nz_mcp/i18n.py
@@ -176,6 +176,27 @@ MESSAGES: Final[dict[str, Message]] = {
         "es": "El backend de keyring no está disponible.",
         "en": "The keyring backend is unavailable.",
     },
+    # probe-catalog CLI
+    "PROBE_CATALOG.HEADER": {
+        "es": "Diagnóstico de catálogo — perfil: {profile}",
+        "en": "Catalog probe — profile: {profile}",
+    },
+    "PROBE_CATALOG.CONFIG_ERROR": {
+        "es": "No se pudo ejecutar el probe de catálogo: {detail}",
+        "en": "Cannot run catalog probe: {detail}",
+    },
+    "PROBE_CATALOG.LINE_OK": {
+        "es": "[OK] {query_id} — {ms:.1f} ms, {rows} filas",
+        "en": "[OK] {query_id} — {ms:.1f} ms, {rows} rows",
+    },
+    "PROBE_CATALOG.LINE_FAIL": {
+        "es": "[FAIL] {query_id}: {detail}",
+        "en": "[FAIL] {query_id}: {detail}",
+    },
+    "PROBE_CATALOG.LINE_WARN": {
+        "es": "[WARN] {query_id} — no validado (falta objeto real): {detail}",
+        "en": "[WARN] {query_id} — not validated (needs real object): {detail}",
+    },
 }
 
 

--- a/tests/integration/test_probe_catalog_real.py
+++ b/tests/integration/test_probe_catalog_real.py
@@ -1,0 +1,29 @@
+"""Optional integration test: ``probe-catalog`` logic against real Netezza."""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+import pytest
+
+from nz_mcp.catalog.probe import run_probe_catalog
+from nz_mcp.catalog.queries import ALL_QUERIES
+from nz_mcp.config import get_active_profile, get_profile
+
+
+@pytest.mark.integration
+def test_real_probe_catalog_run() -> None:
+    if os.environ.get("NZ_MCP_RUN_INTEGRATION") != "1":
+        pytest.skip("Set NZ_MCP_RUN_INTEGRATION=1 to run integration tests against real Netezza")
+
+    config_override = os.environ.get("NZ_MCP_INTEGRATION_PROFILES")
+    config_path = Path(config_override) if config_override else None
+
+    name = os.environ.get("NZ_MCP_INTEGRATION_PROFILE")
+    profile = get_profile(name, path=config_path) if name else get_active_profile(path=config_path)
+
+    run = run_probe_catalog(profile)
+    assert run.profile_name == profile.name
+    if run.config_error is None:
+        assert len(run.results) == len(ALL_QUERIES)

--- a/tests/unit/test_catalog_probe.py
+++ b/tests/unit/test_catalog_probe.py
@@ -83,7 +83,7 @@ def test_run_probe_all_ok(monkeypatch: pytest.MonkeyPatch) -> None:
         def execute(self, *_a: Any, **_k: Any) -> None:
             return None
 
-        def fetchall(self) -> list[tuple[str]]:
+        def fetchall(self) -> list[tuple[str, str]]:
             return [("a", "b")]
 
         def close(self) -> None:

--- a/tests/unit/test_catalog_probe.py
+++ b/tests/unit/test_catalog_probe.py
@@ -1,0 +1,217 @@
+"""Unit tests for catalog probe (faked driver)."""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+import pytest
+
+from nz_mcp.catalog.probe import (
+    dummy_params_for_query_id,
+    prepare_sql,
+    probe_has_hard_failure,
+    probe_one_row,
+    probe_run_to_json_dict,
+    run_probe_catalog,
+)
+from nz_mcp.catalog.queries import ALL_QUERIES
+from nz_mcp.config import Profile
+
+
+def _profile(**overrides: Any) -> Profile:
+    data: dict[str, Any] = {
+        "name": "t",
+        "host": "localhost",
+        "port": 5480,
+        "database": "MYDB",
+        "user": "u",
+        "mode": "read",
+    }
+    data.update(overrides)
+    return Profile.model_validate(data)
+
+
+def test_dummy_params_cover_defaults_and_match_placeholder_count() -> None:
+    for cq in ALL_QUERIES:
+        params = dummy_params_for_query_id(cq.id)
+        assert cq.sql.count("?") == len(params), cq.id
+
+
+def test_prepare_sql_with_override() -> None:
+    prof = _profile(catalog_overrides={"list_databases": "SELECT 1 WHERE ? = ?"})
+    sql = prepare_sql(prof, ALL_QUERIES[0])
+    assert sql == "SELECT 1 WHERE ? = ?"
+
+
+def test_placeholder_mismatch_is_failure(monkeypatch: pytest.MonkeyPatch) -> None:
+    prof = _profile(catalog_overrides={"list_databases": "SELECT 1"})
+    monkeypatch.setattr("nz_mcp.catalog.probe.get_password", lambda _n: "pw")
+
+    class Cursor:
+        def execute(self, *_a: Any, **_k: Any) -> None:
+            raise AssertionError("should not execute")
+
+        def fetchall(self) -> list[Any]:
+            return []
+
+        def close(self) -> None:
+            pass
+
+    class Conn:
+        def cursor(self) -> Cursor:
+            return Cursor()
+
+        def close(self) -> None:
+            pass
+
+    monkeypatch.setattr("nz_mcp.catalog.probe.open_connection", lambda _p, _pw: Conn())
+    run = run_probe_catalog(prof)
+    assert run.config_error is None
+    first = run.results[0]
+    assert first.query_id == "list_databases"
+    assert first.status == "failure"
+    assert first.detail is not None
+    assert "Placeholder count mismatch" in first.detail
+
+
+def test_run_probe_all_ok(monkeypatch: pytest.MonkeyPatch) -> None:
+    prof = _profile()
+    monkeypatch.setattr("nz_mcp.catalog.probe.get_password", lambda _n: "pw")
+
+    class Cursor:
+        def execute(self, *_a: Any, **_k: Any) -> None:
+            return None
+
+        def fetchall(self) -> list[tuple[str]]:
+            return [("a", "b")]
+
+        def close(self) -> None:
+            pass
+
+    class Conn:
+        def cursor(self) -> Cursor:
+            return Cursor()
+
+        def close(self) -> None:
+            pass
+
+    monkeypatch.setattr("nz_mcp.catalog.probe.open_connection", lambda _p, _pw: Conn())
+    run = run_probe_catalog(prof)
+    assert run.config_error is None
+    assert len(run.results) == len(ALL_QUERIES)
+    assert all(r.status == "ok" for r in run.results)
+    assert not probe_has_hard_failure(run)
+
+
+def test_driver_failure(monkeypatch: pytest.MonkeyPatch) -> None:
+    prof = _profile()
+    monkeypatch.setattr("nz_mcp.catalog.probe.get_password", lambda _n: "pw")
+    calls: list[int] = []
+
+    class Cursor:
+        def execute(self, *_a: Any, **_k: Any) -> None:
+            calls.append(1)
+            if len(calls) == 2:
+                raise RuntimeError("forced driver error")
+
+        def fetchall(self) -> list[Any]:
+            return []
+
+        def close(self) -> None:
+            pass
+
+    class Conn:
+        def cursor(self) -> Cursor:
+            return Cursor()
+
+        def close(self) -> None:
+            pass
+
+    monkeypatch.setattr("nz_mcp.catalog.probe.open_connection", lambda _p, _pw: Conn())
+    run = run_probe_catalog(prof)
+    assert run.results[1].status == "failure"
+    assert "forced driver error" in (run.results[1].error_detail or "")
+    assert probe_has_hard_failure(run)
+
+
+def test_structural_warning_not_hard_failure(monkeypatch: pytest.MonkeyPatch) -> None:
+    prof = _profile()
+    monkeypatch.setattr("nz_mcp.catalog.probe.get_password", lambda _n: "pw")
+    n = 0
+
+    class Cursor:
+        def execute(self, *_a: Any, **_k: Any) -> None:
+            nonlocal n
+            n += 1
+            if n == 5:
+                raise RuntimeError("ERROR: Table __NZ_MCP_PROBE_DUMMY__ does not exist")
+
+        def fetchall(self) -> list[Any]:
+            return []
+
+        def close(self) -> None:
+            pass
+
+    class Conn:
+        def cursor(self) -> Cursor:
+            return Cursor()
+
+        def close(self) -> None:
+            pass
+
+    monkeypatch.setattr("nz_mcp.catalog.probe.open_connection", lambda _p, _pw: Conn())
+    run = run_probe_catalog(prof)
+    gv = next(r for r in run.results if r.query_id == "get_view_ddl")
+    assert gv.status == "structural_warning"
+    assert not probe_has_hard_failure(run)
+
+
+def test_invalid_catalog_overrides_rejected() -> None:
+    prof = _profile(catalog_overrides={"not_a_real_id": "SELECT 1"})
+    run = run_probe_catalog(prof)
+    assert run.config_error is not None
+    assert "Unknown catalog_overrides query ids" in run.config_error
+    assert run.results == ()
+    assert probe_has_hard_failure(run)
+
+
+def test_json_shape() -> None:
+    from nz_mcp.catalog.probe import ProbeResult, ProbeRun
+
+    run = ProbeRun(
+        profile_name="x",
+        config_error=None,
+        results=(
+            ProbeResult(
+                query_id="list_databases",
+                status="ok",
+                duration_ms=1.0,
+                row_count=2,
+                error_detail=None,
+                detail=None,
+            ),
+        ),
+    )
+    raw = json.dumps(probe_run_to_json_dict(run))
+    data = json.loads(raw)
+    assert data["profile"] == "x"
+    assert data["config_error"] is None
+    assert data["results"][0]["query_id"] == "list_databases"
+    assert data["results"][0]["status"] == "ok"
+
+
+def test_probe_one_row_direct() -> None:
+    prof = _profile()
+
+    class Cursor:
+        def execute(self, *_a: Any, **_k: Any) -> None:
+            return None
+
+        def fetchall(self) -> list[tuple[int]]:
+            return [(1,)]
+
+    cq = ALL_QUERIES[0]
+    row = probe_one_row(Cursor(), prof, cq)
+    assert row.status == "ok"
+    assert row.row_count == 1


### PR DESCRIPTION
## ¿Qué cambia?

Añade el comando `nz-mcp probe-catalog` para ejecutar todas las consultas registradas en `ALL_QUERIES` contra Netezza usando `resolve_query`, `render_cross_db`, parámetros dummy seguros y clasificación de errores (fallo duro vs advertencia estructural cuando falta un objeto real). Incluye salida legible e i18n ES/EN, opción `--json`, tests unitarios con driver falsificado e integración opcional detrás de `NZ_MCP_RUN_INTEGRATION`.

## Issue relacionado

Closes #31

## Acción según AGENTS.md

- **Ruta (keywords)**: catálogo, driver, nzpy, tests, i18n, README, CHANGELOG
- **Docs leídos**:
  - `docs/standards/pr-audit.md`
  - `docs/standards/git-workflow.md`
  - `docs/standards/testing.md`
  - `docs/roles/data-engineer.md` (catálogo / driver)
  - `AGENTS.md`
- **Rol asumido**: Backend Developer + Data Engineer + QA Engineer

## Archivos esperados (según el issue)

| Esperado | Estado |
|---|---|
| `src/nz_mcp/catalog/probe.py` | ✅ |
| `src/nz_mcp/cli.py` + docstring del módulo | ✅ |
| `src/nz_mcp/i18n.py` | ✅ |
| `tests/unit/test_catalog_probe.py` | ✅ |
| `tests/integration/...` (opcional) | ✅ `test_probe_catalog_real.py` |
| `README.md` / `README.en.md` | ✅ sección diagnóstico catálogo |
| `CHANGELOG.md` | ✅ |

## Auditoría pre-merge — 7 dimensiones

### 1. Contrato y compatibilidad
- [x] Sin cambio de tools MCP: `tools-contract.md` sin cambios.
- [x] `CHANGELOG.md` con entrada bilingüe en `[Unreleased]`.
- [x] Sin breaking change.

### 2. Seguridad
- [x] Las consultas de catálogo **no** pasan por `sql_guard` (igual que el resto del catálogo / `catalog_overrides` documentado); solo SQL parametrizado con `?`, sin concatenar valores de usuario.
- [x] Sin credenciales en código, logs ni tests.

### 3. Mantenibilidad y diseño
- [x] Alcance acotado a CLI + módulo `probe` + tests + docs.
- [x] Sin dependencias nuevas.

### 4. Tests
- [x] Cobertura nueva cubierta con fakes; `pytest -m "not integration"` verde local.
- [x] Cobertura global ≥ 85 % (≈86 % en verificación local).

### 5. Tipado y estilo
- [x] `ruff check` / `ruff format --check` limpios.
- [x] `mypy --strict` limpio en módulos tocados.

### 6. Documentación
- [x] `CHANGELOG.md`, README ES/EN, mensajes i18n ES+EN.

### 7. Idioma y forma
- [x] Código y comentarios en inglés; PR/commits en español.

## Validación humana requerida
- [ ] No — integración opcional con Netezza real solo con `NZ_MCP_RUN_INTEGRATION=1`.

## Notas para el auditor

- El probe valida el mismo SQL que usan las tools de catálogo (incl. overrides); omitir `sql_guard` aquí es coherente con el modelo documentado para consultas de catálogo internas.
