### PR TITLE
security(errors): sanitizar detail de errores del driver con sanitize

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ Cada entrada se documenta en **español** y **english**.
 
 ## [Unreleased]
 
+### Security
+- ES: los mensajes de error del driver en `open_connection`, `list_databases` y `probe-catalog` pasan por `sanitize()` con `known_secrets` para no filtrar contraseñas en el `detail` expuesto al cliente MCP.
+- EN: driver error messages in `open_connection`, `list_databases`, and `probe-catalog` are passed through `sanitize()` with `known_secrets` so passwords are not leaked in MCP-exposed `detail` fields.
+
 ### Added
 - ES: comando CLI `nz-mcp probe-catalog` para validar todas las consultas de catálogo contra Netezza (parámetros dummy, duración, filas; salida `--json` opcional).
 - EN: `nz-mcp probe-catalog` CLI to validate all catalog queries against Netezza (dummy parameters, duration, rows; optional `--json` output).

--- a/src/nz_mcp/catalog/databases.py
+++ b/src/nz_mcp/catalog/databases.py
@@ -11,6 +11,7 @@ from nz_mcp.catalog.resolver import resolve_query
 from nz_mcp.config import Profile
 from nz_mcp.connection import open_connection
 from nz_mcp.errors import NetezzaError
+from nz_mcp.logging_utils import sanitize
 
 _DATABASE_ROW_MIN_ITEMS: Final[int] = 2
 
@@ -43,7 +44,7 @@ def list_databases(profile: Profile, pattern: str | None = None) -> list[dict[st
         raise NetezzaError(
             operation="list_databases",
             database=profile.database,
-            detail=str(exc),
+            detail=sanitize(str(exc), known_secrets={password}),
         ) from exc
     finally:
         connection.close()

--- a/src/nz_mcp/catalog/probe.py
+++ b/src/nz_mcp/catalog/probe.py
@@ -15,6 +15,7 @@ from nz_mcp.config import Profile
 from nz_mcp.connection import open_connection
 from nz_mcp.errors import ConnectionError as NzConnectionError
 from nz_mcp.errors import CredentialNotFoundError, InvalidInputError, InvalidProfileError
+from nz_mcp.logging_utils import sanitize
 
 _DUMMY_SCHEMA: Final[str] = "DBO"
 _DUMMY_OBJECT: Final[str] = "__NZ_MCP_PROBE_DUMMY__"
@@ -114,6 +115,8 @@ def probe_one_row(
     cursor: Any,
     profile: Profile,
     cq: CatalogQuery,
+    *,
+    password: str,
 ) -> ProbeResult:
     """Execute one catalog probe using an open cursor."""
     try:
@@ -146,7 +149,7 @@ def probe_one_row(
         rows = cursor.fetchall()
     except Exception as exc:
         duration_ms = (time.perf_counter() - start) * 1000.0
-        detail_text = str(exc)
+        detail_text = sanitize(str(exc), known_secrets={password})
         if cq.id in _STRUCTURAL_IDS and _looks_like_missing_object(detail_text):
             return ProbeResult(
                 query_id=cq.id,
@@ -198,7 +201,7 @@ def run_probe_catalog(profile: Profile) -> ProbeRun:
         with closing(connection.cursor()) as cursor:
             cur = cast(Any, cursor)
             for cq in ALL_QUERIES:
-                results.append(probe_one_row(cur, profile, cq))
+                results.append(probe_one_row(cur, profile, cq, password=password))
     finally:
         connection.close()
 

--- a/src/nz_mcp/connection.py
+++ b/src/nz_mcp/connection.py
@@ -7,6 +7,7 @@ from typing import TYPE_CHECKING, Final
 import nzpy
 
 from nz_mcp.errors import ConnectionError as NzConnectionError
+from nz_mcp.logging_utils import sanitize
 
 if TYPE_CHECKING:
     from nz_mcp.config import Profile
@@ -33,5 +34,5 @@ def open_connection(profile: Profile, password: str) -> object:
             port=profile.port,
             database=profile.database,
             user=profile.user,
-            detail=str(exc),
+            detail=sanitize(str(exc), known_secrets={password}),
         ) from exc

--- a/tests/unit/test_catalog_databases.py
+++ b/tests/unit/test_catalog_databases.py
@@ -75,6 +75,34 @@ def test_list_databases_queries_catalog_with_optional_like(monkeypatch: pytest.M
     assert connection.closed is True
 
 
+def test_list_databases_sanitizes_password_in_driver_detail(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    known_pw = "known-test-pw"
+
+    class _LeakCursor(_FakeCursor):
+        def execute(self, sql: str, params: tuple[str | None, str | None]) -> None:
+            _ = (sql, params)
+            raise RuntimeError(f"driver error password={known_pw}")
+
+    cursor = _LeakCursor(rows=[])
+    connection = _FakeConnection(cursor)
+    monkeypatch.setattr("nz_mcp.catalog.databases.get_password", lambda _name: known_pw)
+    monkeypatch.setattr(
+        "nz_mcp.catalog.databases.open_connection",
+        lambda *_args, **_kwargs: connection,
+    )
+    monkeypatch.setattr(
+        "nz_mcp.catalog.databases.resolve_query",
+        lambda _query_id, _profile: "SELECT DATABASE, OWNER FROM _V_DATABASE",
+    )
+
+    with pytest.raises(NetezzaError) as exc:
+        list_databases(_profile(), pattern=None)
+
+    assert known_pw not in exc.value.context["detail"]
+
+
 def test_list_databases_wraps_driver_errors_and_closes_connection(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/unit/test_catalog_probe.py
+++ b/tests/unit/test_catalog_probe.py
@@ -212,6 +212,6 @@ def test_probe_one_row_direct() -> None:
             return [(1,)]
 
     cq = ALL_QUERIES[0]
-    row = probe_one_row(Cursor(), prof, cq)
+    row = probe_one_row(Cursor(), prof, cq, password="unit-test-password")  # noqa: S106
     assert row.status == "ok"
     assert row.row_count == 1

--- a/tests/unit/test_connection.py
+++ b/tests/unit/test_connection.py
@@ -46,6 +46,23 @@ def test_open_connection_calls_nzpy_with_expected_parameters(
     assert captured["securityLevel"] == 1
 
 
+def test_open_connection_sanitizes_known_password_in_driver_detail(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    known_pw = "known-test-pw"
+
+    def _raise_with_password(**_kwargs: object) -> object:
+        raise RuntimeError(f"connection failed: dsn contains password={known_pw}")
+
+    monkeypatch.setattr("nz_mcp.connection.nzpy.connect", _raise_with_password)
+
+    with pytest.raises(NzConnectionError) as exc:
+        open_connection(_profile(), known_pw)
+
+    detail = exc.value.context["detail"]
+    assert known_pw not in detail
+
+
 def test_open_connection_wraps_driver_failures(monkeypatch: pytest.MonkeyPatch) -> None:
     def _raise_connect(**_kwargs: object) -> object:
         raise RuntimeError("dial timeout")


### PR DESCRIPTION
## ¿Qué cambia?

Se aplica `logging_utils.sanitize()` al `detail` de errores originados en el driver (`nzpy` / cursor) en `open_connection`, `list_databases` y en el path de ejecución de `probe-catalog`, usando `known_secrets={password}` cuando la contraseña del perfil está en alcance. Así se evita que un mensaje de excepción que replique connection string u otros secretos llegue al contexto de errores expuesto vía MCP.

## Issue relacionado

Closes #25

## Acción según AGENTS.md

- **Ruta (keywords)**: auth, credenciales, driver, sql_guard (errores que propagan info del driver)
- **Docs leídos**:
  - `docs/architecture/security-model.md`
  - `docs/roles/security-engineer.md`
  - `docs/standards/coding.md`
  - `docs/standards/pr-audit.md`
  - `AGENTS.md`
- **Rol asumido**: Security Engineer

## Auditoría pre-merge — 7 dimensiones

### 1. Contrato y compatibilidad
- [x] Sin cambio de contrato de tools MCP.
- [x] `CHANGELOG.md` con entrada bilingüe bajo `### Security` en `[Unreleased]`.
- [x] Sin breaking change de API pública (solo contenido sanitizado de `detail`).

### 2. Seguridad
- [x] SQL sigue parametrizado; no se añade concatenación de secretos.
- [x] Tests adversariales: password conocido `known-test-pw` no aparece en `context["detail"]` tras errores simulados del driver.
- [x] Sin credenciales en código de producción; tests usan valores ficticios explícitos.

### 3. Mantenibilidad y diseño
- [x] Cambio acotado a los archivos esperados por el issue + `probe.py` (otro sitio con `detail=str(exc)` del driver).
- [x] Sin nuevas dependencias; reutiliza `sanitize` existente.

### 4. Tests
- [x] Nuevos tests en `test_connection.py` y `test_catalog_databases.py`.
- [x] `pytest -m "not integration"` verde local.
- [x] Ajuste de test de `probe_one_row` por nuevo parámetro `password`.

### 5. Tipado y estilo
- [x] `ruff check . --fix` y `ruff format .` ejecutados antes del commit.
- [x] `mypy` sin errores.

### 6. Documentación
- [x] `CHANGELOG.md` (ES + EN).

### 7. Idioma y forma
- [x] Código y comentarios en inglés; PR/commits en español.

## Validación humana requerida

- [ ] No — comportamiento de seguridad cubierto por tests automatizados.

## Notas para el auditor

- Otros `detail=str(exc)` en `config.py`, `auth.py`, `server.py`, etc. no provienen de mensajes del driver de Netezza con connection string; quedan fuera del alcance explícito del issue (solo conexión/catálogo/probe del driver).
