### PR TITLE
refactor(connection): documentar except defensivo del driver con noqa BLE001

### DIFF
--- a/src/nz_mcp/catalog/databases.py
+++ b/src/nz_mcp/catalog/databases.py
@@ -40,7 +40,8 @@ def list_databases(profile: Profile, pattern: str | None = None) -> list[dict[st
         with closing(connection.cursor()) as cursor:
             cursor.execute(sql, params)
             rows = cursor.fetchall()
-    except Exception as exc:
+    except Exception as exc:  # noqa: BLE001, RUF100
+        # Catalog/driver failures are not guaranteed to use a stable exception type.
         raise NetezzaError(
             operation="list_databases",
             database=profile.database,

--- a/src/nz_mcp/connection.py
+++ b/src/nz_mcp/connection.py
@@ -28,7 +28,8 @@ def open_connection(profile: Profile, password: str) -> object:
             application_name=APPLICATION_NAME,
             securityLevel=1,
         )
-    except Exception as exc:
+    except Exception as exc:  # noqa: BLE001, RUF100
+        # nzpy may raise unchecked driver errors; we surface them as typed ConnectionError for MCP.
         raise NzConnectionError(
             host=profile.host,
             port=profile.port,


### PR DESCRIPTION
## ¿Qué cambia?

Documenta explícitamente el `except Exception` defensivo en `open_connection` y `list_databases` con `# noqa: BLE001, RUF100` y un comentario breve, alineado con `_probe_keyring` en `diagnostic.py`. Sin cambio de comportamiento.

## Issue relacionado

Closes #26

## Acción según AGENTS.md

- **Ruta (keywords)**: refactor, mantenibilidad, ruff
- **Docs leídos**:
  - `docs/standards/coding.md`
  - `docs/standards/pr-audit.md`
  - `AGENTS.md`
- **Rol asumido**: Backend Developer

## Auditoría pre-merge — 7 dimensiones

### 1. Contrato y compatibilidad
- [N/A: sin cambio observable] — sin entrada en CHANGELOG (refactor interno).

### 2. Seguridad
- [x] Sin cambio de lógica ni de manejo de secretos.

### 3. Mantenibilidad y diseño
- [x] Diff mínimo (~15 líneas); patrón igual a `diagnostic._probe_keyring`.

### 4. Tests
- [x] Tests existentes sin cambios; `pytest -m "not integration"` verde local.

### 5. Tipado y estilo
- [x] `ruff check . --fix` y `ruff format .` ejecutados.

### 6. Documentación
- [N/A: no aplica] — sin cambio de README; CHANGELOG omitido a propósito.

### 7. Idioma y forma
- [x] Comentarios en inglés; PR/commits en español.

## Validación humana requerida

- [ ] No

## Notas para el auditor

- Objetivo: silenciar BLE001 de forma explícita y documentada; `RUF100` evita que ruff elimine el `noqa` cuando la regla BLE001 no está habilitada en el entorno.
