### PR TITLE
refactor(config): promueve single_profile_name_or_none a API pública

### DIFF
--- a/src/nz_mcp/config.py
+++ b/src/nz_mcp/config.py
@@ -87,12 +87,16 @@ def get_profile(name: str, path: Path | None = None) -> Profile:
 
 def get_active_profile(path: Path | None = None) -> Profile:
     file = load_profiles_file(path)
-    name = file.active or os.environ.get("NZ_MCP_PROFILE") or _single_profile_or_none(file)
+    name = file.active or os.environ.get("NZ_MCP_PROFILE") or single_profile_name_or_none(file)
     if not name:
         raise ProfileNotFoundError(profile="<active>")
     return get_profile(name, path=path)
 
 
-def _single_profile_or_none(file: ProfilesFile) -> str | None:
+def single_profile_name_or_none(file: ProfilesFile) -> str | None:
+    """Return the profile name when ``file`` defines exactly one profile, else ``None``.
+
+    Used to infer the active profile when ``active`` and ``NZ_MCP_PROFILE`` are unset.
+    """
     keys = list(file.profiles.keys())
     return keys[0] if len(keys) == 1 else None

--- a/src/nz_mcp/diagnostic.py
+++ b/src/nz_mcp/diagnostic.py
@@ -17,10 +17,10 @@ from pydantic import BaseModel, ConfigDict
 
 from nz_mcp import __version__
 from nz_mcp.config import (
-    _single_profile_or_none,
     config_dir,
     load_profiles_file,
     profiles_path,
+    single_profile_name_or_none,
 )
 from nz_mcp.errors import InvalidProfileError
 from nz_mcp.i18n import Locale, resolve_locale, t
@@ -113,7 +113,7 @@ def collect_diagnostic(
             profiles_count = len(data.profiles)
             profiles_names = tuple(sorted(data.profiles.keys()))
             active_profile = (
-                data.active or os.environ.get("NZ_MCP_PROFILE") or _single_profile_or_none(data)
+                data.active or os.environ.get("NZ_MCP_PROFILE") or single_profile_name_or_none(data)
             )
 
     kr_name, kr_ok = _probe_keyring()


### PR DESCRIPTION
## ¿Qué cambia?

Renombra `_single_profile_or_none` a `single_profile_name_or_none` en `config.py`, con docstring en inglés, y actualiza el uso en `diagnostic.py`. Comportamiento idéntico; API pública más clara.

## Issue relacionado

Closes #16

## Acción según AGENTS.md

- **Ruta (keywords)**: refactor, config, mantenibilidad
- **Docs leídos**:
  - `docs/standards/coding.md`
  - `docs/standards/pr-audit.md`
  - `AGENTS.md`
- **Rol asumido**: Backend Developer

## Auditoría pre-merge — 7 dimensiones

### 1. Contrato y compatibilidad
- [N/A: sin cambio observable de producto] — sin CHANGELOG.

### 2. Seguridad
- [x] Sin impacto en credenciales ni SQL.

### 3. Mantenibilidad y diseño
- [x] Refactor mínimo; nombre exportado más descriptivo.

### 4. Tests
- [x] `pytest -m "not integration"` verde sin tocar tests.

### 5. Tipado y estilo
- [x] `ruff check . --fix` y `ruff format .` ejecutados.

### 6. Documentación
- [N/A] — docstring en código; sin README.

### 7. Idioma y forma
- [x] Docstring en inglés; PR/commits en español.

## Validación humana requerida

- [ ] No

## Notas para el auditor

- `get_active_profile` pasa a usar el símbolo público; `diagnostic` importa desde `config` el mismo nombre.
