### PR TITLE
docs(readme): literaliza salida de ejemplo de nz-mcp doctor

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -55,17 +55,26 @@ To inspect your local environment (Python version, config paths, profile names w
 nz-mcp doctor
 ```
 
-Sample output (abbreviated):
+Sample literal output (reference Linux environment, Python 3.11; fictional paths and profiles ``demo`` / ``dev`` / ``prod`` — same shape as ``format_diagnostic_report`` in the package):
 
 ```text
 Local diagnostics (nz-mcp doctor)
 
 nz-mcp version: 0.1.0a0
-Python version: 3.11.x
-...
+Python version: 3.11.9
+Platform: Linux-6.8.0-generic-x86_64-with-glibc2.39
+Configuration directory: /home/demo/.nz-mcp
+  Exists: yes
+  Writable: yes
+Profiles path: /home/demo/.nz-mcp/profiles.toml
+  Exists: yes
+Profiles load OK: yes
+Profile count: 2
 Profile names: dev, prod
-Active profile: dev
-...
+Active profile: prod
+Keyring backend: SecretService Keyring
+  Available: yes
+Locale: en
 ```
 
 Exit code: `0` when the setup is OK; `1` on a critical issue (e.g. keyring unavailable).

--- a/README.md
+++ b/README.md
@@ -55,17 +55,26 @@ Para revisar el entorno local (versión de Python, rutas de config, perfiles sin
 nz-mcp doctor
 ```
 
-Ejemplo de salida (resumido):
+Ejemplo de salida literal (referencia Linux, Python 3.11; rutas y perfiles ficticios ``demo`` / ``dev`` / ``prod`` — coincide con ``format_diagnostic_report`` del paquete):
 
 ```text
 Diagnóstico local (nz-mcp doctor)
 
 Versión nz-mcp: 0.1.0a0
-Versión de Python: 3.11.x
-...
+Versión de Python: 3.11.9
+Plataforma: Linux-6.8.0-generic-x86_64-with-glibc2.39
+Directorio de configuración: /home/demo/.nz-mcp
+  Existe: sí
+  Escribible: sí
+Ruta de perfiles: /home/demo/.nz-mcp/profiles.toml
+  Existe: sí
+Carga de perfiles OK: sí
+Número de perfiles: 2
 Nombres de perfiles: dev, prod
-Perfil activo: dev
-...
+Perfil activo: prod
+Backend de keyring: SecretService Keyring
+  Disponible: sí
+Idioma (locale): es
 ```
 
 Código de salida: `0` si el entorno es usable; `1` si hay un problema crítico (p. ej. keyring no disponible).


### PR DESCRIPTION
## ¿Qué cambia?

Sustituye los ejemplos truncados con `...` en las secciones **Diagnóstico** / **Diagnostics** de `README.md` y `README.en.md` por salida literal alineada con `format_diagnostic_report` (mismos campos que `DiagnosticReport`), usando un entorno de referencia Linux y rutas/perfiles ficticios sin credenciales.

## Issue relacionado

Closes #18

## Acción según AGENTS.md

- **Ruta (keywords)**: README, docs, i18n
- **Docs leídos**:
  - `docs/roles/technical-writer.md`
  - `docs/standards/i18n.md`
  - `docs/standards/pr-audit.md`
  - `AGENTS.md`
- **Rol asumido**: Technical Writer

## Auditoría pre-merge — 7 dimensiones

### 1. Contrato y compatibilidad
- [x] Solo documentación; sin cambio de paquete instalado — sin CHANGELOG (según issue).

### 2. Seguridad
- [x] Sin hostnames, usuarios ni secretos reales; valores ficticios explícitos.

### 3. Mantenibilidad y diseño
- [x] Solo secciones indicadas del README ES/EN.

### 4. Tests
- [N/A] — sin cambios de código.

### 5. Tipado y estilo
- [x] `ruff check .` ejecutado (sin cambios en código Python).

### 6. Documentación
- [x] Paridad ES/EN en estructura; etiquetas según i18n del doctor.

### 7. Idioma y forma
- [x] README ES principal, EN en `README.en.md`.

## Validación humana requerida

- [ ] No

## Notas para el auditor

- La salida ES/EN se validó contra `format_diagnostic_report` con un `DiagnosticReport` ficticio (locale `es` vs `en` en la última línea).
