### PR TITLE
feat(tools): implementa nz_list_schemas

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ Cada entrada se documenta en **español** y **english**.
 - EN: driver error messages in `open_connection`, `list_databases`, and `probe-catalog` are passed through `sanitize()` with `known_secrets` so passwords are not leaked in MCP-exposed `detail` fields.
 
 ### Added
+- ES: tool `nz_list_schemas` para listar schemas en una base vía catálogo `_v_schema` (cross-database).
+- EN: `nz_list_schemas` tool to list schemas in a database via `_v_schema` catalog (cross-database).
 - ES: comando CLI `nz-mcp probe-catalog` para validar todas las consultas de catálogo contra Netezza (parámetros dummy, duración, filas; salida `--json` opcional).
 - EN: `nz-mcp probe-catalog` CLI to validate all catalog queries against Netezza (dummy parameters, duration, rows; optional `--json` output).
 - ES: soporte `catalog_overrides` por perfil para resolver SQL de catálogo por `query_id` desde `profiles.toml`.

--- a/docs/architecture/tools-contract.md
+++ b/docs/architecture/tools-contract.md
@@ -81,7 +81,8 @@ Lista bases de datos visibles para el usuario del perfil.
 
 | Input | Tipo | Descripción |
 |---|---|---|
-| `database` | string (required) | BD a inspeccionar. |
+| `database` | string (required) | BD a inspeccionar (identificador validado para interpolación `<BD>..`). |
+| `pattern` | string (optional) | Filtro tipo `LIKE` sobre el nombre de schema. |
 
 **Output**: `{ "schemas": [{"name": "PUBLIC", "owner": "ADMIN"}] }`
 

--- a/src/nz_mcp/catalog/schemas.py
+++ b/src/nz_mcp/catalog/schemas.py
@@ -1,0 +1,68 @@
+"""Catalog queries for schemas."""
+
+from __future__ import annotations
+
+from contextlib import closing
+from typing import Any, Final, Protocol, cast
+
+from nz_mcp.auth import get_password
+from nz_mcp.catalog.identifier import render_cross_db
+from nz_mcp.catalog.resolver import resolve_query
+from nz_mcp.config import Profile
+from nz_mcp.connection import open_connection
+from nz_mcp.errors import NetezzaError
+from nz_mcp.logging_utils import sanitize
+
+_SCHEMA_ROW_MIN_ITEMS: Final[int] = 2
+
+
+class _CursorLike(Protocol):
+    def execute(self, sql: str, params: tuple[str | None, str | None]) -> None: ...
+    def fetchall(self) -> list[Any]: ...
+    def close(self) -> None: ...
+
+
+class _ConnectionLike(Protocol):
+    def cursor(self) -> _CursorLike: ...
+    def close(self) -> None: ...
+
+
+def list_schemas(
+    profile: Profile, database: str, pattern: str | None = None
+) -> list[dict[str, str]]:
+    """Return schemas from ``_v_schema`` for ``database`` using cross-database notation."""
+    like_pattern = pattern if pattern else None
+    params: tuple[str | None, str | None] = (like_pattern, like_pattern)
+    password = get_password(profile.name)
+    base_sql = resolve_query("list_schemas", profile)
+    sql = render_cross_db(base_sql, database=database)
+
+    connection = cast(_ConnectionLike, open_connection(profile, password))
+    try:
+        with closing(connection.cursor()) as cursor:
+            cursor.execute(sql, params)
+            rows = cursor.fetchall()
+    except Exception as exc:  # noqa: BLE001, RUF100
+        # Catalog/driver failures are not guaranteed to use a stable exception type.
+        raise NetezzaError(
+            operation="list_schemas",
+            database=database,
+            detail=sanitize(str(exc), known_secrets={password}),
+        ) from exc
+    finally:
+        connection.close()
+
+    return [_row_to_schema(row) for row in rows]
+
+
+def _row_to_schema(row: Any) -> dict[str, str]:
+    if isinstance(row, dict):
+        if "SCHEMA" not in row or "OWNER" not in row:
+            raise NetezzaError(
+                operation="list_schemas",
+                detail="Catalog query must return SCHEMA and OWNER columns.",
+            )
+        return {"name": str(row["SCHEMA"]), "owner": str(row["OWNER"])}
+    if isinstance(row, tuple) and len(row) >= _SCHEMA_ROW_MIN_ITEMS:
+        return {"name": str(row[0]), "owner": str(row[1])}
+    raise NetezzaError(operation="list_schemas", detail="Unexpected row shape from _v_schema")

--- a/src/nz_mcp/tools/__init__.py
+++ b/src/nz_mcp/tools/__init__.py
@@ -7,6 +7,7 @@ from __future__ import annotations
 
 from nz_mcp.tools import (
     databases,  # noqa: F401  (registers database tools)
+    schemas,  # noqa: F401  (registers schema tools)
     session,  # noqa: F401  (registers session tools)
 )
 from nz_mcp.tools.registry import TOOLS, ToolSpec

--- a/src/nz_mcp/tools/schemas.py
+++ b/src/nz_mcp/tools/schemas.py
@@ -1,0 +1,50 @@
+"""Schema catalog tools."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from pydantic import BaseModel, ConfigDict, Field
+
+from nz_mcp.catalog.schemas import list_schemas
+from nz_mcp.config import get_active_profile
+from nz_mcp.tools.registry import tool
+
+
+class ListSchemasInput(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+    database: str = Field(min_length=1, max_length=128)
+    pattern: str | None = Field(default=None, min_length=1, max_length=128)
+
+
+class SchemaItem(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+    name: str
+    owner: str
+
+
+class ListSchemasOutput(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+    schemas: list[SchemaItem]
+
+
+@tool(
+    name="nz_list_schemas",
+    description=(
+        "List Netezza schemas in a database. "
+        "Use for discovering schema names before listing tables. "
+        "Do not use for databases or table metadata."
+    ),
+    mode="read",
+    input_model=ListSchemasInput,
+    output_model=ListSchemasOutput,
+    annotations={"readOnlyHint": True, "idempotentHint": True, "openWorldHint": False},
+)
+def nz_list_schemas(
+    params: ListSchemasInput,
+    *,
+    config_path: Path | None = None,
+) -> ListSchemasOutput:
+    profile = get_active_profile(path=config_path)
+    rows = list_schemas(profile, database=params.database, pattern=params.pattern)
+    return ListSchemasOutput(schemas=[SchemaItem(**row) for row in rows])

--- a/tests/contract/test_mcp_tool_schemas.py
+++ b/tests/contract/test_mcp_tool_schemas.py
@@ -15,6 +15,7 @@ from nz_mcp.tools.registry import TOOLS
 EXPECTED_V010A0: set[str] = {
     "nz_current_profile",
     "nz_list_databases",
+    "nz_list_schemas",
     "nz_switch_profile",
 }
 

--- a/tests/integration/test_real_list_schemas.py
+++ b/tests/integration/test_real_list_schemas.py
@@ -1,0 +1,22 @@
+"""Integration test for ``nz_list_schemas`` against real Netezza."""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+import pytest
+
+from nz_mcp.tools.schemas import ListSchemasInput, nz_list_schemas
+
+
+@pytest.mark.integration
+def test_real_nz_list_schemas() -> None:
+    if os.environ.get("NZ_MCP_RUN_INTEGRATION") != "1":
+        pytest.skip("Set NZ_MCP_RUN_INTEGRATION=1 to run integration tests against real Netezza")
+
+    config_override = os.environ.get("NZ_MCP_INTEGRATION_PROFILES")
+    config_path = Path(config_override) if config_override else None
+
+    out = nz_list_schemas(ListSchemasInput(database="DEV"), config_path=config_path)
+    assert isinstance(out.schemas, list)

--- a/tests/unit/test_catalog_schemas.py
+++ b/tests/unit/test_catalog_schemas.py
@@ -1,0 +1,130 @@
+"""Tests for schema catalog queries."""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+import pytest
+
+from nz_mcp.catalog.schemas import list_schemas
+from nz_mcp.config import Profile
+from nz_mcp.errors import NetezzaError
+
+
+class _FakeCursor:
+    def __init__(self, rows: list[object]) -> None:
+        self.rows = rows
+        self.closed = False
+        self.executed_sql: str | None = None
+        self.executed_params: tuple[str | None, str | None] | None = None
+
+    def execute(self, sql: str, params: tuple[str | None, str | None]) -> None:
+        self.executed_sql = sql
+        self.executed_params = params
+
+    def fetchall(self) -> Sequence[object]:
+        return self.rows
+
+    def close(self) -> None:
+        self.closed = True
+
+
+class _FakeConnection:
+    def __init__(self, cursor: _FakeCursor) -> None:
+        self._cursor = cursor
+        self.closed = False
+
+    def cursor(self) -> _FakeCursor:
+        return self._cursor
+
+    def close(self) -> None:
+        self.closed = True
+
+
+def _profile() -> Profile:
+    return Profile(
+        name="dev",
+        host="nz-dev.example.com",
+        port=5480,
+        database="DEV",
+        user="svc_dev",
+        mode="read",
+    )
+
+
+def test_list_schemas_queries_catalog_with_optional_like(monkeypatch: pytest.MonkeyPatch) -> None:
+    cursor = _FakeCursor(rows=[("PUBLIC", "ADMIN"), ("STG", "ETL")])
+    connection = _FakeConnection(cursor)
+
+    monkeypatch.setattr("nz_mcp.catalog.schemas.get_password", lambda _name: "pw")
+    monkeypatch.setattr(
+        "nz_mcp.catalog.schemas.open_connection",
+        lambda *_args, **_kwargs: connection,
+    )
+    monkeypatch.setattr(
+        "nz_mcp.catalog.schemas.resolve_query",
+        lambda _query_id, _profile: (
+            "SELECT SCHEMA, OWNER FROM <BD>.._V_SCHEMA WHERE (? IS NULL OR SCHEMA LIKE ?)"
+        ),
+    )
+
+    out = list_schemas(_profile(), database="ANALYTICS", pattern="P%")
+
+    assert out == [
+        {"name": "PUBLIC", "owner": "ADMIN"},
+        {"name": "STG", "owner": "ETL"},
+    ]
+    assert cursor.executed_sql is not None
+    assert "_v_schema" in cursor.executed_sql.lower()
+    assert "<bd>" not in cursor.executed_sql.lower()
+    assert "ANALYTICS.." in cursor.executed_sql
+    assert cursor.executed_params == ("P%", "P%")
+    assert cursor.closed is True
+    assert connection.closed is True
+
+
+def test_list_schemas_wraps_driver_errors(monkeypatch: pytest.MonkeyPatch) -> None:
+    class _BoomCursor(_FakeCursor):
+        def execute(self, sql: str, params: tuple[str | None, str | None]) -> None:
+            _ = (sql, params)
+            raise RuntimeError("catalog unavailable")
+
+    cursor = _BoomCursor(rows=[])
+    connection = _FakeConnection(cursor)
+    monkeypatch.setattr("nz_mcp.catalog.schemas.get_password", lambda _name: "known-test-pw")
+    monkeypatch.setattr(
+        "nz_mcp.catalog.schemas.open_connection",
+        lambda *_args, **_kwargs: connection,
+    )
+    monkeypatch.setattr(
+        "nz_mcp.catalog.schemas.resolve_query",
+        lambda _query_id, _profile: "SELECT SCHEMA, OWNER FROM <BD>.._V_SCHEMA",
+    )
+
+    with pytest.raises(NetezzaError) as exc:
+        list_schemas(_profile(), database="MYDB", pattern=None)
+
+    assert exc.value.code == "NETEZZA_ERROR"
+    assert "catalog unavailable" in exc.value.context["detail"]
+    assert "known-test-pw" not in exc.value.context["detail"]
+    assert cursor.closed is True
+    assert connection.closed is True
+
+
+def test_list_schemas_rejects_bad_row_shape(monkeypatch: pytest.MonkeyPatch) -> None:
+    cursor = _FakeCursor(rows=[("ONLYONE",)])
+    connection = _FakeConnection(cursor)
+    monkeypatch.setattr("nz_mcp.catalog.schemas.get_password", lambda _name: "pw")
+    monkeypatch.setattr(
+        "nz_mcp.catalog.schemas.open_connection",
+        lambda *_args, **_kwargs: connection,
+    )
+    monkeypatch.setattr(
+        "nz_mcp.catalog.schemas.resolve_query",
+        lambda _query_id, _profile: "SELECT SCHEMA, OWNER FROM <BD>.._V_SCHEMA",
+    )
+
+    with pytest.raises(NetezzaError) as exc:
+        list_schemas(_profile(), database="MYDB")
+
+    assert "Unexpected row shape" in exc.value.context["detail"]

--- a/tests/unit/test_tools_list_schemas.py
+++ b/tests/unit/test_tools_list_schemas.py
@@ -1,0 +1,51 @@
+"""Tests for ``nz_list_schemas`` tool."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from nz_mcp.errors import NetezzaError
+from nz_mcp.tools.schemas import ListSchemasInput, nz_list_schemas
+
+
+def test_nz_list_schemas_happy_path(monkeypatch: pytest.MonkeyPatch, two_profiles: Path) -> None:
+    def _fake_list_schemas(
+        _profile: object,
+        database: str,
+        pattern: str | None = None,
+    ) -> list[dict[str, str]]:
+        assert database == "DEV"
+        assert pattern == "P%"
+        return [
+            {"name": "PUBLIC", "owner": "ADMIN"},
+            {"name": "PRD", "owner": "DBA"},
+        ]
+
+    monkeypatch.setattr("nz_mcp.tools.schemas.list_schemas", _fake_list_schemas)
+    out = nz_list_schemas(
+        ListSchemasInput(database="DEV", pattern="P%"),
+        config_path=two_profiles,
+    )
+
+    assert [item.name for item in out.schemas] == ["PUBLIC", "PRD"]
+    assert [item.owner for item in out.schemas] == ["ADMIN", "DBA"]
+
+
+def test_nz_list_schemas_propagates_typed_errors(
+    monkeypatch: pytest.MonkeyPatch, two_profiles: Path
+) -> None:
+    def _raise_list_schemas(
+        _profile: object,
+        database: str,
+        pattern: str | None = None,
+    ) -> list[dict[str, str]]:
+        raise NetezzaError(operation="list_schemas", detail="denied")
+
+    monkeypatch.setattr("nz_mcp.tools.schemas.list_schemas", _raise_list_schemas)
+
+    with pytest.raises(NetezzaError) as exc:
+        nz_list_schemas(ListSchemasInput(database="DEV"), config_path=two_profiles)
+
+    assert exc.value.code == "NETEZZA_ERROR"


### PR DESCRIPTION
## ¿Qué cambia?
Expone el listado de esquemas Netezza vía MCP, alineado con `nz_list_databases`: consulta de catálogo con `resolve_query` + `render_cross_db`, filtro opcional por patrón LIKE y manejo de errores sanitizado.

## Issue relacionado
Closes #40

## Acción según AGENTS.md
- **Ruta (keywords)**: nueva tool, catalog, tools-contract
- **Docs leídos**:
  - `docs/architecture/tools-contract.md`
  - `AGENTS.md`
- **Rol asumido**: Backend Developer

## Archivos esperados (según el issue)
- `src/nz_mcp/catalog/schemas.py` (nuevo)
- `src/nz_mcp/tools/schemas.py` (nuevo)
- `src/nz_mcp/tools/__init__.py`
- `docs/architecture/tools-contract.md`
- `tests/contract/test_mcp_tool_schemas.py`
- `tests/unit/test_catalog_schemas.py`, `tests/unit/test_tools_list_schemas.py`
- `tests/integration/test_real_list_schemas.py`
- `CHANGELOG.md`

## Auditoría pre-merge — 7 dimensiones

### 1. Contrato y compatibilidad
- [x] Si toca tools: `docs/architecture/tools-contract.md` actualizado en este PR.
- [x] Si hay cambio observable: `CHANGELOG.md` con entrada bilingüe en `Unreleased`.
- [x] Sin breaking change inesperado.

### 2. Seguridad
- [x] Todo SQL pasa por `sql_guard.validate()`. (N/A: catálogo interno; mismo patrón que list_databases)
- [x] Sin SQL concatenado (parametrizado).
- [x] Sin credenciales en código, logs, tests, fixtures, comentarios.
- [x] Si toca `sql_guard.py` o `auth.py`: cobertura sigue en 100 %. (no tocados)
- [x] Si toca `sql_guard.py`: ≥ 3 tests adversariales nuevos. (no tocado)

### 3. Mantenibilidad y diseño
- [x] Toqué solo los archivos esperados (o documenté por qué no).
- [x] Sin abstracciones nuevas sin 3 usos reales.
- [x] Sin dependencias nuevas sin ADR.
- [x] Funciones < 50 LoC, args < 4.
- [x] Una intención por PR.
- [x] PR < 400 LoC sin tests/docs (o justificado).

### 4. Tests
- [x] Tests para todo comportamiento nuevo.
- [x] `pytest -m "not integration"` verde local.
- [x] Cobertura ≥ 85 % global, no cae respecto a `main`. (CI)
- [x] Sin `pytest.skip()` ni `xfail` sin issue.

### 5. Tipado y estilo
- [x] `ruff check .` y `ruff format --check .` limpios.
- [x] `mypy --strict` limpio en módulos tocados.
- [x] Sin `Any` en superficies públicas sin justificación.
- [x] Sin `except Exception:` sin re-raise tipado.

### 6. Documentación
- [x] Si cambia API pública: `tools-contract.md` actualizado.
- [x] Si cambia comportamiento: `CHANGELOG.md` actualizado (ES + EN).
- [x] Si introduce decisión arquitectónica: nuevo ADR en `docs/adr/`. (no)
- [x] Mensajes nuevos: claves añadidas en ES **y** EN. (N/A)

### 7. Idioma y forma
- [x] Título de PR en español, formato conventional commit.
- [x] Branch cumple regex (validado por CI).
- [x] Commits en español, conventional (validados por CI).
- [x] Código y comentarios en inglés.

## Validación humana requerida
- [ ] Sí — explicar por qué:
- [x] No

## Notas para el auditor
Herramienta de solo lectura; integración detrás de `NZ_MCP_RUN_INTEGRATION=1`.
