### PR TITLE
feat(tools): implementa nz_list_tables

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ Cada entrada se documenta en **español** y **english**.
 - EN: driver error messages in `open_connection`, `list_databases`, and `probe-catalog` are passed through `sanitize()` with `known_secrets` so passwords are not leaked in MCP-exposed `detail` fields.
 
 ### Added
+- ES: tool `nz_list_tables` para listar tablas base en un schema vía catálogo `_v_table` (sin vistas; cross-database).
+- EN: `nz_list_tables` tool to list base tables in a schema via `_v_table` catalog (not views; cross-database).
 - ES: tool `nz_list_schemas` para listar schemas en una base vía catálogo `_v_schema` (cross-database).
 - EN: `nz_list_schemas` tool to list schemas in a database via `_v_schema` catalog (cross-database).
 - ES: comando CLI `nz-mcp probe-catalog` para validar todas las consultas de catálogo contra Netezza (parámetros dummy, duración, filas; salida `--json` opcional).

--- a/docs/architecture/tools-contract.md
+++ b/docs/architecture/tools-contract.md
@@ -98,11 +98,12 @@ Lista **solo tablas** (no vistas, no procedimientos). Para vistas usar `nz_list_
 | `schema` | string (required) | |
 | `pattern` | string (optional) | Filtro `LIKE` por nombre. |
 
-**Output**:
+**Output** (solo `name` y `kind`; el conteo de filas va en `nz_table_stats`):
+
 ```json
 {
   "tables": [
-    {"name": "CUSTOMERS", "kind": "TABLE", "row_count_estimate": 1200000}
+    {"name": "CUSTOMERS", "kind": "TABLE"}
   ]
 }
 ```

--- a/src/nz_mcp/catalog/tables.py
+++ b/src/nz_mcp/catalog/tables.py
@@ -1,0 +1,80 @@
+"""Catalog queries for tables."""
+
+from __future__ import annotations
+
+from contextlib import closing
+from typing import Any, Final, Protocol, cast
+
+from nz_mcp.auth import get_password
+from nz_mcp.catalog.identifier import render_cross_db
+from nz_mcp.catalog.resolver import resolve_query
+from nz_mcp.config import Profile
+from nz_mcp.connection import open_connection
+from nz_mcp.errors import NetezzaError
+from nz_mcp.logging_utils import sanitize
+
+_TABLE_ROW_MIN_ITEMS: Final[int] = 2
+_TABLE_KIND: Final[str] = "TABLE"
+
+
+class _CursorLike(Protocol):
+    def execute(
+        self,
+        sql: str,
+        params: tuple[str, str | None, str | None],
+    ) -> None: ...
+
+    def fetchall(self) -> list[Any]: ...
+    def close(self) -> None: ...
+
+
+class _ConnectionLike(Protocol):
+    def cursor(self) -> _CursorLike: ...
+    def close(self) -> None: ...
+
+
+def list_tables(
+    profile: Profile,
+    database: str,
+    schema: str,
+    pattern: str | None = None,
+) -> list[dict[str, str]]:
+    """Return tables from ``_v_table`` for ``database`` and ``schema`` (cross-database notation)."""
+    like_pattern = pattern if pattern else None
+    params: tuple[str, str | None, str | None] = (schema, like_pattern, like_pattern)
+    password = get_password(profile.name)
+    base_sql = resolve_query("list_tables", profile)
+    sql = render_cross_db(base_sql, database=database)
+
+    connection = cast(_ConnectionLike, open_connection(profile, password))
+    try:
+        with closing(connection.cursor()) as cursor:
+            cursor.execute(sql, params)
+            rows = cursor.fetchall()
+    except Exception as exc:  # noqa: BLE001, RUF100
+        # Catalog/driver failures are not guaranteed to use a stable exception type.
+        raise NetezzaError(
+            operation="list_tables",
+            database=database,
+            detail=sanitize(str(exc), known_secrets={password}),
+        ) from exc
+    finally:
+        connection.close()
+
+    return [_row_to_table(row) for row in rows]
+
+
+def _row_to_table(row: Any) -> dict[str, str]:
+    if isinstance(row, dict):
+        name_key = "NAME" if "NAME" in row else None
+        if name_key is None and "TABLENAME" in row:
+            name_key = "TABLENAME"
+        if name_key is None:
+            raise NetezzaError(
+                operation="list_tables",
+                detail="Catalog query must return NAME (or TABLENAME) column.",
+            )
+        return {"name": str(row[name_key]), "kind": _TABLE_KIND}
+    if isinstance(row, tuple) and len(row) >= _TABLE_ROW_MIN_ITEMS:
+        return {"name": str(row[0]), "kind": _TABLE_KIND}
+    raise NetezzaError(operation="list_tables", detail="Unexpected row shape from _v_table")

--- a/src/nz_mcp/tools/__init__.py
+++ b/src/nz_mcp/tools/__init__.py
@@ -9,6 +9,7 @@ from nz_mcp.tools import (
     databases,  # noqa: F401  (registers database tools)
     schemas,  # noqa: F401  (registers schema tools)
     session,  # noqa: F401  (registers session tools)
+    tables,  # noqa: F401  (registers table tools)
 )
 from nz_mcp.tools.registry import TOOLS, ToolSpec
 

--- a/src/nz_mcp/tools/tables.py
+++ b/src/nz_mcp/tools/tables.py
@@ -1,0 +1,63 @@
+"""Table catalog tools."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Literal
+
+from pydantic import BaseModel, ConfigDict, Field
+
+from nz_mcp.catalog.tables import list_tables
+from nz_mcp.config import get_active_profile
+from nz_mcp.tools.registry import tool
+
+
+class ListTablesInput(BaseModel):
+    model_config = ConfigDict(extra="forbid", populate_by_name=True)
+    database: str = Field(min_length=1, max_length=128)
+    table_schema: str = Field(
+        alias="schema",
+        min_length=1,
+        max_length=128,
+    )
+    pattern: str | None = Field(default=None, min_length=1, max_length=128)
+
+
+class TableItem(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+    name: str
+    kind: Literal["TABLE"] = "TABLE"
+
+
+class ListTablesOutput(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+    tables: list[TableItem]
+
+
+@tool(
+    name="nz_list_tables",
+    description=(
+        "List Netezza base tables in a schema (not views). "
+        "Use before describing columns or sampling. "
+        "Do not use for views, procedures, or stats."
+    ),
+    mode="read",
+    input_model=ListTablesInput,
+    output_model=ListTablesOutput,
+    annotations={"readOnlyHint": True, "idempotentHint": True, "openWorldHint": False},
+)
+def nz_list_tables(
+    params: ListTablesInput,
+    *,
+    config_path: Path | None = None,
+) -> ListTablesOutput:
+    profile = get_active_profile(path=config_path)
+    rows = list_tables(
+        profile,
+        database=params.database,
+        schema=params.table_schema,
+        pattern=params.pattern,
+    )
+    return ListTablesOutput(
+        tables=[TableItem(name=row["name"], kind="TABLE") for row in rows],
+    )

--- a/tests/contract/test_mcp_tool_schemas.py
+++ b/tests/contract/test_mcp_tool_schemas.py
@@ -16,6 +16,7 @@ EXPECTED_V010A0: set[str] = {
     "nz_current_profile",
     "nz_list_databases",
     "nz_list_schemas",
+    "nz_list_tables",
     "nz_switch_profile",
 }
 

--- a/tests/integration/test_real_list_tables.py
+++ b/tests/integration/test_real_list_tables.py
@@ -1,0 +1,25 @@
+"""Integration test for ``nz_list_tables`` against real Netezza."""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+import pytest
+
+from nz_mcp.tools.tables import ListTablesInput, nz_list_tables
+
+
+@pytest.mark.integration
+def test_real_nz_list_tables() -> None:
+    if os.environ.get("NZ_MCP_RUN_INTEGRATION") != "1":
+        pytest.skip("Set NZ_MCP_RUN_INTEGRATION=1 to run integration tests against real Netezza")
+
+    config_override = os.environ.get("NZ_MCP_INTEGRATION_PROFILES")
+    config_path = Path(config_override) if config_override else None
+
+    out = nz_list_tables(
+        ListTablesInput(database="DEV", table_schema="PUBLIC"),
+        config_path=config_path,
+    )
+    assert isinstance(out.tables, list)

--- a/tests/unit/test_catalog_tables.py
+++ b/tests/unit/test_catalog_tables.py
@@ -1,0 +1,193 @@
+"""Tests for table catalog queries."""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+import pytest
+
+from nz_mcp.catalog.tables import list_tables
+from nz_mcp.config import Profile
+from nz_mcp.errors import NetezzaError
+
+
+class _FakeCursor:
+    def __init__(self, rows: list[object]) -> None:
+        self.rows = rows
+        self.closed = False
+        self.executed_sql: str | None = None
+        self.executed_params: tuple[str, str | None, str | None] | None = None
+
+    def execute(
+        self,
+        sql: str,
+        params: tuple[str, str | None, str | None],
+    ) -> None:
+        self.executed_sql = sql
+        self.executed_params = params
+
+    def fetchall(self) -> Sequence[object]:
+        return self.rows
+
+    def close(self) -> None:
+        self.closed = True
+
+
+class _FakeConnection:
+    def __init__(self, cursor: _FakeCursor) -> None:
+        self._cursor = cursor
+        self.closed = False
+
+    def cursor(self) -> _FakeCursor:
+        return self._cursor
+
+    def close(self) -> None:
+        self.closed = True
+
+
+def _profile() -> Profile:
+    return Profile(
+        name="dev",
+        host="nz-dev.example.com",
+        port=5480,
+        database="DEV",
+        user="svc_dev",
+        mode="read",
+    )
+
+
+def test_list_tables_queries_catalog_with_optional_like(monkeypatch: pytest.MonkeyPatch) -> None:
+    cursor = _FakeCursor(rows=[("T1", "OWN"), ("T2", "OWN")])
+    connection = _FakeConnection(cursor)
+
+    monkeypatch.setattr("nz_mcp.catalog.tables.get_password", lambda _name: "pw")
+    monkeypatch.setattr(
+        "nz_mcp.catalog.tables.open_connection",
+        lambda *_args, **_kwargs: connection,
+    )
+    monkeypatch.setattr(
+        "nz_mcp.catalog.tables.resolve_query",
+        lambda _query_id, _profile: (
+            "SELECT TABLENAME AS NAME, OWNER FROM <BD>.._V_TABLE "
+            "WHERE SCHEMA = UPPER(?) AND OBJTYPE='TABLE' "
+            "AND (? IS NULL OR TABLENAME LIKE ?) ORDER BY TABLENAME"
+        ),
+    )
+
+    out = list_tables(_profile(), database="ANALYTICS", schema="PUBLIC", pattern="T%")
+
+    assert out == [
+        {"name": "T1", "kind": "TABLE"},
+        {"name": "T2", "kind": "TABLE"},
+    ]
+    assert cursor.executed_sql is not None
+    assert "_v_table" in cursor.executed_sql.lower()
+    assert "<bd>" not in cursor.executed_sql.lower()
+    assert "ANALYTICS.." in cursor.executed_sql
+    assert cursor.executed_params == ("PUBLIC", "T%", "T%")
+    assert cursor.closed is True
+    assert connection.closed is True
+
+
+def test_list_tables_accepts_dict_rows_with_name_alias(monkeypatch: pytest.MonkeyPatch) -> None:
+    cursor = _FakeCursor(rows=[{"NAME": "T1", "OWNER": "O"}])
+    connection = _FakeConnection(cursor)
+    monkeypatch.setattr("nz_mcp.catalog.tables.get_password", lambda _name: "pw")
+    monkeypatch.setattr(
+        "nz_mcp.catalog.tables.open_connection",
+        lambda *_args, **_kwargs: connection,
+    )
+    monkeypatch.setattr(
+        "nz_mcp.catalog.tables.resolve_query",
+        lambda _query_id, _profile: "SELECT TABLENAME AS NAME, OWNER FROM <BD>.._V_TABLE",
+    )
+
+    out = list_tables(_profile(), database="DB", schema="S", pattern=None)
+    assert out == [{"name": "T1", "kind": "TABLE"}]
+
+
+def test_list_tables_accepts_dict_rows_with_tablename(monkeypatch: pytest.MonkeyPatch) -> None:
+    cursor = _FakeCursor(rows=[{"TABLENAME": "T1", "OWNER": "O"}])
+    connection = _FakeConnection(cursor)
+    monkeypatch.setattr("nz_mcp.catalog.tables.get_password", lambda _name: "pw")
+    monkeypatch.setattr(
+        "nz_mcp.catalog.tables.open_connection",
+        lambda *_args, **_kwargs: connection,
+    )
+    monkeypatch.setattr(
+        "nz_mcp.catalog.tables.resolve_query",
+        lambda _query_id, _profile: "SELECT TABLENAME, OWNER FROM <BD>.._V_TABLE",
+    )
+
+    out = list_tables(_profile(), database="DB", schema="S", pattern=None)
+    assert out == [{"name": "T1", "kind": "TABLE"}]
+
+
+def test_list_tables_wraps_driver_errors(monkeypatch: pytest.MonkeyPatch) -> None:
+    class _BoomCursor(_FakeCursor):
+        def execute(
+            self,
+            sql: str,
+            params: tuple[str, str | None, str | None],
+        ) -> None:
+            _ = (sql, params)
+            raise RuntimeError("catalog unavailable")
+
+    cursor = _BoomCursor(rows=[])
+    connection = _FakeConnection(cursor)
+    monkeypatch.setattr("nz_mcp.catalog.tables.get_password", lambda _name: "known-test-pw")
+    monkeypatch.setattr(
+        "nz_mcp.catalog.tables.open_connection",
+        lambda *_args, **_kwargs: connection,
+    )
+    monkeypatch.setattr(
+        "nz_mcp.catalog.tables.resolve_query",
+        lambda _query_id, _profile: "SELECT TABLENAME AS NAME, OWNER FROM <BD>.._V_TABLE",
+    )
+
+    with pytest.raises(NetezzaError) as exc:
+        list_tables(_profile(), database="MYDB", schema="PUB", pattern=None)
+
+    assert exc.value.code == "NETEZZA_ERROR"
+    assert "catalog unavailable" in exc.value.context["detail"]
+    assert "known-test-pw" not in exc.value.context["detail"]
+    assert cursor.closed is True
+    assert connection.closed is True
+
+
+def test_list_tables_rejects_bad_row_shape(monkeypatch: pytest.MonkeyPatch) -> None:
+    cursor = _FakeCursor(rows=[("ONLYONE",)])
+    connection = _FakeConnection(cursor)
+    monkeypatch.setattr("nz_mcp.catalog.tables.get_password", lambda _name: "pw")
+    monkeypatch.setattr(
+        "nz_mcp.catalog.tables.open_connection",
+        lambda *_args, **_kwargs: connection,
+    )
+    monkeypatch.setattr(
+        "nz_mcp.catalog.tables.resolve_query",
+        lambda _query_id, _profile: "SELECT TABLENAME AS NAME, OWNER FROM <BD>.._V_TABLE",
+    )
+
+    with pytest.raises(NetezzaError) as exc:
+        list_tables(_profile(), database="MYDB", schema="X")
+
+    assert "Unexpected row shape" in exc.value.context["detail"]
+
+
+def test_list_tables_rejects_dict_without_name(monkeypatch: pytest.MonkeyPatch) -> None:
+    cursor = _FakeCursor(rows=[{"OWNER": "O"}])
+    connection = _FakeConnection(cursor)
+    monkeypatch.setattr("nz_mcp.catalog.tables.get_password", lambda _name: "pw")
+    monkeypatch.setattr(
+        "nz_mcp.catalog.tables.open_connection",
+        lambda *_args, **_kwargs: connection,
+    )
+    monkeypatch.setattr(
+        "nz_mcp.catalog.tables.resolve_query",
+        lambda _query_id, _profile: "SELECT TABLENAME AS NAME, OWNER FROM <BD>.._V_TABLE",
+    )
+
+    with pytest.raises(NetezzaError) as exc:
+        list_tables(_profile(), database="MYDB", schema="X")
+
+    assert "Catalog query must return" in exc.value.context["detail"]

--- a/tests/unit/test_tools_list_tables.py
+++ b/tests/unit/test_tools_list_tables.py
@@ -1,0 +1,62 @@
+"""Tests for ``nz_list_tables`` tool."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from nz_mcp.errors import NetezzaError
+from nz_mcp.tools.tables import ListTablesInput, nz_list_tables
+
+
+def test_list_tables_input_accepts_wire_schema_key() -> None:
+    parsed = ListTablesInput.model_validate({"database": "DEV", "schema": "PUBLIC"})
+    assert parsed.table_schema == "PUBLIC"
+
+
+def test_nz_list_tables_happy_path(monkeypatch: pytest.MonkeyPatch, two_profiles: Path) -> None:
+    def _fake_list_tables(
+        _profile: object,
+        database: str,
+        schema: str,
+        pattern: str | None = None,
+    ) -> list[dict[str, str]]:
+        assert database == "DEV"
+        assert schema == "PUBLIC"
+        assert pattern == "C%"
+        return [
+            {"name": "CUSTOMERS", "kind": "TABLE"},
+            {"name": "CONFIG", "kind": "TABLE"},
+        ]
+
+    monkeypatch.setattr("nz_mcp.tools.tables.list_tables", _fake_list_tables)
+    out = nz_list_tables(
+        ListTablesInput(database="DEV", table_schema="PUBLIC", pattern="C%"),
+        config_path=two_profiles,
+    )
+
+    assert [t.name for t in out.tables] == ["CUSTOMERS", "CONFIG"]
+    assert [t.kind for t in out.tables] == ["TABLE", "TABLE"]
+
+
+def test_nz_list_tables_propagates_typed_errors(
+    monkeypatch: pytest.MonkeyPatch, two_profiles: Path
+) -> None:
+    def _raise_list_tables(
+        _profile: object,
+        database: str,
+        schema: str,
+        pattern: str | None = None,
+    ) -> list[dict[str, str]]:
+        raise NetezzaError(operation="list_tables", detail="denied")
+
+    monkeypatch.setattr("nz_mcp.tools.tables.list_tables", _raise_list_tables)
+
+    with pytest.raises(NetezzaError) as exc:
+        nz_list_tables(
+            ListTablesInput(database="DEV", table_schema="PUBLIC"),
+            config_path=two_profiles,
+        )
+
+    assert exc.value.code == "NETEZZA_ERROR"


### PR DESCRIPTION
## ¿Qué cambia?
Expone el listado de **tablas base** en un schema Netezza vía MCP, usando la query centralizada `LIST_TABLES` (`_v_table`, `OBJTYPE='TABLE'`), con filtro opcional por nombre y el mismo patrón cross-database que `nz_list_schemas`.

## Issue relacionado
Closes #41

## Acción según AGENTS.md
- **Ruta (keywords)**: nueva tool, catálogo
- **Docs leídos**:
  - `docs/architecture/tools-contract.md`
  - `AGENTS.md`
- **Rol asumido**: Backend Developer + Data Engineer

## Archivos esperados (según el issue)
- `src/nz_mcp/catalog/tables.py`
- `src/nz_mcp/tools/tables.py`
- `src/nz_mcp/tools/__init__.py`
- `tests/unit/test_catalog_tables.py`
- `tests/unit/test_tools_list_tables.py`
- `tests/integration/test_real_list_tables.py`
- `tests/contract/test_mcp_tool_schemas.py`
- `CHANGELOG.md`
- `docs/architecture/tools-contract.md` (salida simplificada: solo `name` y `kind`)

## Auditoría pre-merge — 7 dimensiones

### 1. Contrato y compatibilidad
- [x] Si toca tools: `docs/architecture/tools-contract.md` actualizado en este PR.
- [x] Si hay cambio observable: `CHANGELOG.md` con entrada bilingüe en `Unreleased`.
- [x] Sin breaking change inesperado.

### 2. Seguridad
- [x] SQL parametrizado (sin concatenación de valores de usuario).
- [x] Sin credenciales en código, logs, tests, fixtures, comentarios.

### 3. Mantenibilidad y diseño
- [x] Toqué solo los archivos esperados (o documenté por qué no).
- [x] Una intención por PR.

### 4. Tests
- [x] Tests para comportamiento nuevo.
- [x] `pytest -m "not integration"` verde local.

### 5. Tipado y estilo
- [x] `ruff check .` y `ruff format --check .` limpios.
- [x] `mypy --strict` limpio en módulos tocados.

### 6. Documentación
- [x] `tools-contract.md` y `CHANGELOG.md` actualizados (ES + EN en Added).

### 7. Idioma y forma
- [x] Título de PR en español, conventional commit.
- [x] Código y comentarios en inglés.

## Validación humana requerida
- [x] No

## Notas para el auditor
- Campo de entrada `schema` en JSON MCP: en el modelo Pydantic se usa `table_schema` con `alias="schema"` para no sombrear `BaseModel.schema`.
- Integración opcional con `NZ_MCP_RUN_INTEGRATION=1`.
