### PR TITLE
feat(tools): implementa nz_list_views y nz_get_view_ddl

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ Cada entrada se documenta en **español** y **english**.
 - EN: driver error messages in `open_connection`, `list_databases`, and `probe-catalog` are passed through `sanitize()` with `known_secrets` so passwords are not leaked in MCP-exposed `detail` fields.
 
 ### Added
+- ES: tool `nz_get_view_ddl` para obtener el DDL `CREATE VIEW` desde `_v_view` (cross-database).
+- EN: `nz_get_view_ddl` tool to fetch `CREATE VIEW` DDL from `_v_view` (cross-database).
+- ES: tool `nz_list_views` para listar vistas en un schema vía catálogo `_v_view` (cross-database).
+- EN: `nz_list_views` tool to list views in a schema via `_v_view` catalog (cross-database).
 - ES: tool `nz_list_tables` para listar tablas base en un schema vía catálogo `_v_table` (sin vistas; cross-database).
 - EN: `nz_list_tables` tool to list base tables in a schema via `_v_table` catalog (not views; cross-database).
 - ES: tool `nz_list_schemas` para listar schemas en una base vía catálogo `_v_schema` (cross-database).

--- a/src/nz_mcp/catalog/views.py
+++ b/src/nz_mcp/catalog/views.py
@@ -1,0 +1,144 @@
+"""Catalog queries for views."""
+
+from __future__ import annotations
+
+from contextlib import closing
+from typing import Any, Final, Protocol, cast
+
+from nz_mcp.auth import get_password
+from nz_mcp.catalog.identifier import render_cross_db
+from nz_mcp.catalog.resolver import resolve_query
+from nz_mcp.config import Profile
+from nz_mcp.connection import open_connection
+from nz_mcp.errors import NetezzaError
+from nz_mcp.logging_utils import sanitize
+
+_VIEW_LIST_MIN_ITEMS: Final[int] = 2
+
+
+class _ListCursor(Protocol):
+    def execute(
+        self,
+        sql: str,
+        params: tuple[str, str | None, str | None],
+    ) -> None: ...
+
+    def fetchall(self) -> list[Any]: ...
+    def close(self) -> None: ...
+
+
+class _DdlCursor(Protocol):
+    def execute(
+        self,
+        sql: str,
+        params: tuple[str, str],
+    ) -> None: ...
+
+    def fetchone(self) -> Any: ...
+    def close(self) -> None: ...
+
+
+class _ConnectionForList(Protocol):
+    def cursor(self) -> _ListCursor: ...
+    def close(self) -> None: ...
+
+
+class _ConnectionForDdl(Protocol):
+    def cursor(self) -> _DdlCursor: ...
+    def close(self) -> None: ...
+
+
+def list_views(
+    profile: Profile,
+    database: str,
+    schema: str,
+    pattern: str | None = None,
+) -> list[dict[str, str]]:
+    """Return views from ``_v_view`` for ``database`` and ``schema`` (cross-database)."""
+    like_pattern = pattern if pattern else None
+    params: tuple[str, str | None, str | None] = (schema, like_pattern, like_pattern)
+    password = get_password(profile.name)
+    base_sql = resolve_query("list_views", profile)
+    sql = render_cross_db(base_sql, database=database)
+
+    connection = cast(_ConnectionForList, open_connection(profile, password))
+    try:
+        with closing(connection.cursor()) as cursor:
+            cursor.execute(sql, params)
+            rows = cursor.fetchall()
+    except Exception as exc:  # noqa: BLE001, RUF100
+        raise NetezzaError(
+            operation="list_views",
+            database=database,
+            detail=sanitize(str(exc), known_secrets={password}),
+        ) from exc
+    finally:
+        connection.close()
+
+    return [_row_to_view_list_item(row) for row in rows]
+
+
+def get_view_ddl(
+    profile: Profile,
+    database: str,
+    schema: str,
+    view: str,
+) -> str:
+    """Return the ``DEFINITION`` text for a view from ``_v_view``."""
+    params: tuple[str, str] = (schema, view)
+    password = get_password(profile.name)
+    base_sql = resolve_query("get_view_ddl", profile)
+    sql = render_cross_db(base_sql, database=database)
+
+    connection = cast(_ConnectionForDdl, open_connection(profile, password))
+    try:
+        with closing(connection.cursor()) as cursor:
+            cursor.execute(sql, params)
+            row = cursor.fetchone()
+    except Exception as exc:  # noqa: BLE001, RUF100
+        raise NetezzaError(
+            operation="get_view_ddl",
+            database=database,
+            detail=sanitize(str(exc), known_secrets={password}),
+        ) from exc
+    finally:
+        connection.close()
+
+    if row is None:
+        raise NetezzaError(
+            operation="get_view_ddl",
+            database=database,
+            detail="No view definition returned for the given schema and view name.",
+        )
+    return _row_to_definition(row)
+
+
+def _row_to_view_list_item(row: Any) -> dict[str, str]:
+    if isinstance(row, dict):
+        name_key = "NAME" if "NAME" in row else None
+        if name_key is None and "VIEWNAME" in row:
+            name_key = "VIEWNAME"
+        if name_key is None or "OWNER" not in row:
+            raise NetezzaError(
+                operation="list_views",
+                detail="Catalog query must return NAME (or VIEWNAME) and OWNER columns.",
+            )
+        return {"name": str(row[name_key]), "owner": str(row["OWNER"])}
+    if isinstance(row, tuple) and len(row) >= _VIEW_LIST_MIN_ITEMS:
+        return {"name": str(row[0]), "owner": str(row[1])}
+    raise NetezzaError(operation="list_views", detail="Unexpected row shape from _v_view")
+
+
+def _row_to_definition(row: Any) -> str:
+    if isinstance(row, dict):
+        if "DEFINITION" not in row:
+            raise NetezzaError(
+                operation="get_view_ddl",
+                detail="Catalog query must return a DEFINITION column.",
+            )
+        text = row["DEFINITION"]
+        return "" if text is None else str(text)
+    if isinstance(row, tuple) and len(row) >= 1:
+        cell = row[0]
+        return "" if cell is None else str(cell)
+    raise NetezzaError(operation="get_view_ddl", detail="Unexpected row shape from _v_view")

--- a/src/nz_mcp/tools/__init__.py
+++ b/src/nz_mcp/tools/__init__.py
@@ -10,6 +10,7 @@ from nz_mcp.tools import (
     schemas,  # noqa: F401  (registers schema tools)
     session,  # noqa: F401  (registers session tools)
     tables,  # noqa: F401  (registers table tools)
+    views,  # noqa: F401  (registers view tools)
 )
 from nz_mcp.tools.registry import TOOLS, ToolSpec
 

--- a/src/nz_mcp/tools/views.py
+++ b/src/nz_mcp/tools/views.py
@@ -1,0 +1,103 @@
+"""View catalog tools."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from pydantic import BaseModel, ConfigDict, Field
+
+from nz_mcp.catalog.views import get_view_ddl, list_views
+from nz_mcp.config import get_active_profile
+from nz_mcp.tools.registry import tool
+
+
+class ListViewsInput(BaseModel):
+    model_config = ConfigDict(extra="forbid", populate_by_name=True)
+    database: str = Field(min_length=1, max_length=128)
+    view_schema: str = Field(
+        alias="schema",
+        min_length=1,
+        max_length=128,
+    )
+    pattern: str | None = Field(default=None, min_length=1, max_length=128)
+
+
+class ViewItem(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+    name: str
+    owner: str
+
+
+class ListViewsOutput(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+    views: list[ViewItem]
+
+
+class GetViewDdlInput(BaseModel):
+    model_config = ConfigDict(extra="forbid", populate_by_name=True)
+    database: str = Field(min_length=1, max_length=128)
+    view_schema: str = Field(
+        alias="schema",
+        min_length=1,
+        max_length=128,
+    )
+    view: str = Field(min_length=1, max_length=128)
+
+
+class GetViewDdlOutput(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+    ddl: str
+
+
+@tool(
+    name="nz_list_views",
+    description=(
+        "List Netezza views in a schema. "
+        "Use to discover view names before fetching DDL. "
+        "Do not use for tables, materialized views, or procedures."
+    ),
+    mode="read",
+    input_model=ListViewsInput,
+    output_model=ListViewsOutput,
+    annotations={"readOnlyHint": True, "idempotentHint": True, "openWorldHint": False},
+)
+def nz_list_views(
+    params: ListViewsInput,
+    *,
+    config_path: Path | None = None,
+) -> ListViewsOutput:
+    profile = get_active_profile(path=config_path)
+    rows = list_views(
+        profile,
+        database=params.database,
+        schema=params.view_schema,
+        pattern=params.pattern,
+    )
+    return ListViewsOutput(views=[ViewItem(name=r["name"], owner=r["owner"]) for r in rows])
+
+
+@tool(
+    name="nz_get_view_ddl",
+    description=(
+        "Return CREATE VIEW DDL text for one view from the system catalog. "
+        "Call after resolving the view name (e.g. via nz_list_views). "
+        "Do not use for tables or procedures."
+    ),
+    mode="read",
+    input_model=GetViewDdlInput,
+    output_model=GetViewDdlOutput,
+    annotations={"readOnlyHint": True, "idempotentHint": True, "openWorldHint": False},
+)
+def nz_get_view_ddl(
+    params: GetViewDdlInput,
+    *,
+    config_path: Path | None = None,
+) -> GetViewDdlOutput:
+    profile = get_active_profile(path=config_path)
+    ddl = get_view_ddl(
+        profile,
+        database=params.database,
+        schema=params.view_schema,
+        view=params.view,
+    )
+    return GetViewDdlOutput(ddl=ddl)

--- a/tests/contract/test_mcp_tool_schemas.py
+++ b/tests/contract/test_mcp_tool_schemas.py
@@ -14,9 +14,11 @@ from nz_mcp.tools.registry import TOOLS
 
 EXPECTED_V010A0: set[str] = {
     "nz_current_profile",
+    "nz_get_view_ddl",
     "nz_list_databases",
     "nz_list_schemas",
     "nz_list_tables",
+    "nz_list_views",
     "nz_switch_profile",
 }
 

--- a/tests/integration/test_real_views.py
+++ b/tests/integration/test_real_views.py
@@ -1,0 +1,49 @@
+"""Integration tests for view tools against real Netezza."""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+import pytest
+
+from nz_mcp.tools.views import GetViewDdlInput, ListViewsInput, nz_get_view_ddl, nz_list_views
+
+
+@pytest.mark.integration
+def test_real_nz_list_views() -> None:
+    if os.environ.get("NZ_MCP_RUN_INTEGRATION") != "1":
+        pytest.skip("Set NZ_MCP_RUN_INTEGRATION=1 to run integration tests against real Netezza")
+
+    config_override = os.environ.get("NZ_MCP_INTEGRATION_PROFILES")
+    config_path = Path(config_override) if config_override else None
+
+    out = nz_list_views(
+        ListViewsInput(database="DEV", view_schema="PUBLIC"),
+        config_path=config_path,
+    )
+    assert isinstance(out.views, list)
+
+
+@pytest.mark.integration
+def test_real_nz_get_view_ddl() -> None:
+    if os.environ.get("NZ_MCP_RUN_INTEGRATION") != "1":
+        pytest.skip("Set NZ_MCP_RUN_INTEGRATION=1 to run integration tests against real Netezza")
+
+    config_override = os.environ.get("NZ_MCP_INTEGRATION_PROFILES")
+    config_path = Path(config_override) if config_override else None
+
+    listed = nz_list_views(
+        ListViewsInput(database="DEV", view_schema="PUBLIC"),
+        config_path=config_path,
+    )
+    if not listed.views:
+        pytest.skip("No views in PUBLIC to fetch DDL for")
+
+    first = listed.views[0].name
+    out = nz_get_view_ddl(
+        GetViewDdlInput(database="DEV", view_schema="PUBLIC", view=first),
+        config_path=config_path,
+    )
+    assert isinstance(out.ddl, str)
+    assert len(out.ddl) > 0

--- a/tests/unit/test_catalog_views.py
+++ b/tests/unit/test_catalog_views.py
@@ -1,0 +1,249 @@
+"""Tests for view catalog queries."""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+import pytest
+
+from nz_mcp.catalog.views import get_view_ddl, list_views
+from nz_mcp.config import Profile
+from nz_mcp.errors import NetezzaError
+
+
+class _FakeListCursor:
+    def __init__(self, rows: list[object]) -> None:
+        self.rows = rows
+        self.closed = False
+        self.executed_sql: str | None = None
+        self.executed_params: tuple[str, str | None, str | None] | None = None
+
+    def execute(
+        self,
+        sql: str,
+        params: tuple[str, str | None, str | None],
+    ) -> None:
+        self.executed_sql = sql
+        self.executed_params = params
+
+    def fetchall(self) -> Sequence[object]:
+        return self.rows
+
+    def close(self) -> None:
+        self.closed = True
+
+
+class _FakeDdlCursor:
+    def __init__(self, one: object | None) -> None:
+        self._one = one
+        self.closed = False
+        self.executed_sql: str | None = None
+        self.executed_params: tuple[str, str] | None = None
+
+    def execute(self, sql: str, params: tuple[str, str]) -> None:
+        self.executed_sql = sql
+        self.executed_params = params
+
+    def fetchone(self) -> object | None:
+        return self._one
+
+    def close(self) -> None:
+        self.closed = True
+
+
+class _FakeListConnection:
+    def __init__(self, cursor: _FakeListCursor) -> None:
+        self._cursor = cursor
+        self.closed = False
+
+    def cursor(self) -> _FakeListCursor:
+        return self._cursor
+
+    def close(self) -> None:
+        self.closed = True
+
+
+class _FakeDdlConnection:
+    def __init__(self, cursor: _FakeDdlCursor) -> None:
+        self._cursor = cursor
+        self.closed = False
+
+    def cursor(self) -> _FakeDdlCursor:
+        return self._cursor
+
+    def close(self) -> None:
+        self.closed = True
+
+
+def _profile() -> Profile:
+    return Profile(
+        name="dev",
+        host="nz-dev.example.com",
+        port=5480,
+        database="DEV",
+        user="svc_dev",
+        mode="read",
+    )
+
+
+def test_list_views_queries_catalog_with_optional_like(monkeypatch: pytest.MonkeyPatch) -> None:
+    cursor = _FakeListCursor(rows=[("V1", "A"), ("V2", "A")])
+    connection = _FakeListConnection(cursor)
+    monkeypatch.setattr("nz_mcp.catalog.views.get_password", lambda _n: "pw")
+    monkeypatch.setattr(
+        "nz_mcp.catalog.views.open_connection",
+        lambda *_a, **_k: connection,
+    )
+    monkeypatch.setattr(
+        "nz_mcp.catalog.views.resolve_query",
+        lambda _i, _p: (
+            "SELECT VIEWNAME AS NAME, OWNER, X FROM <BD>.._V_VIEW "
+            "WHERE SCHEMA = UPPER(?) AND (? IS NULL OR VIEWNAME LIKE ?) ORDER BY VIEWNAME"
+        ),
+    )
+
+    out = list_views(_profile(), database="ANALYTICS", schema="PUBLIC", pattern="V%")
+    assert out == [
+        {"name": "V1", "owner": "A"},
+        {"name": "V2", "owner": "A"},
+    ]
+    assert cursor.executed_params == ("PUBLIC", "V%", "V%")
+    assert "_v_view" in (cursor.executed_sql or "").lower()
+    assert "ANALYTICS.." in (cursor.executed_sql or "")
+
+
+def test_list_views_dict_row_with_name_owner(monkeypatch: pytest.MonkeyPatch) -> None:
+    cursor = _FakeListCursor(rows=[{"NAME": "V1", "OWNER": "O", "CREATEDATE": None}])
+    connection = _FakeListConnection(cursor)
+    monkeypatch.setattr("nz_mcp.catalog.views.get_password", lambda _n: "pw")
+    monkeypatch.setattr("nz_mcp.catalog.views.open_connection", lambda *_a, **_k: connection)
+    monkeypatch.setattr(
+        "nz_mcp.catalog.views.resolve_query",
+        lambda _i, _p: "SELECT VIEWNAME AS NAME, OWNER FROM <BD>.._V_VIEW",
+    )
+    assert list_views(_profile(), database="DB", schema="S") == [{"name": "V1", "owner": "O"}]
+
+
+def test_list_views_wraps_driver_errors(monkeypatch: pytest.MonkeyPatch) -> None:
+    class _Boom(_FakeListCursor):
+        def execute(
+            self,
+            sql: str,
+            params: tuple[str, str | None, str | None],
+        ) -> None:
+            _ = (sql, params)
+            raise RuntimeError("catalog down")
+
+    cursor = _Boom(rows=[])
+    connection = _FakeListConnection(cursor)
+    monkeypatch.setattr("nz_mcp.catalog.views.get_password", lambda _n: "secret-pw")
+    monkeypatch.setattr("nz_mcp.catalog.views.open_connection", lambda *_a, **_k: connection)
+    monkeypatch.setattr(
+        "nz_mcp.catalog.views.resolve_query",
+        lambda _i, _p: "SELECT VIEWNAME AS NAME FROM <BD>.._V_VIEW",
+    )
+
+    with pytest.raises(NetezzaError) as exc:
+        list_views(_profile(), database="X", schema="Y")
+
+    assert "catalog down" in exc.value.context["detail"]
+    assert "secret-pw" not in exc.value.context["detail"]
+
+
+def test_list_views_rejects_bad_row_shape(monkeypatch: pytest.MonkeyPatch) -> None:
+    cursor = _FakeListCursor(rows=[("only",)])
+    connection = _FakeListConnection(cursor)
+    monkeypatch.setattr("nz_mcp.catalog.views.get_password", lambda _n: "pw")
+    monkeypatch.setattr("nz_mcp.catalog.views.open_connection", lambda *_a, **_k: connection)
+    monkeypatch.setattr(
+        "nz_mcp.catalog.views.resolve_query",
+        lambda _i, _p: "SELECT VIEWNAME AS NAME, OWNER FROM <BD>.._V_VIEW",
+    )
+
+    with pytest.raises(NetezzaError) as exc:
+        list_views(_profile(), database="D", schema="S")
+
+    assert "Unexpected row shape" in exc.value.context["detail"]
+
+
+def test_get_view_ddl_returns_definition(monkeypatch: pytest.MonkeyPatch) -> None:
+    cursor = _FakeDdlCursor(one=("CREATE VIEW ...",))
+    connection = _FakeDdlConnection(cursor)
+    monkeypatch.setattr("nz_mcp.catalog.views.get_password", lambda _n: "pw")
+    monkeypatch.setattr("nz_mcp.catalog.views.open_connection", lambda *_a, **_k: connection)
+    monkeypatch.setattr(
+        "nz_mcp.catalog.views.resolve_query",
+        lambda _i, _p: (
+            "SELECT DEFINITION FROM <BD>.._V_VIEW WHERE SCHEMA = UPPER(?) AND VIEWNAME = UPPER(?)"
+        ),
+    )
+
+    assert get_view_ddl(_profile(), database="DB", schema="PUB", view="V1") == "CREATE VIEW ..."
+    assert cursor.executed_params == ("PUB", "V1")
+
+
+def test_get_view_ddl_dict_row(monkeypatch: pytest.MonkeyPatch) -> None:
+    cursor = _FakeDdlCursor(one={"DEFINITION": "CREATE VIEW X AS SELECT 1"})
+    connection = _FakeDdlConnection(cursor)
+    monkeypatch.setattr("nz_mcp.catalog.views.get_password", lambda _n: "pw")
+    monkeypatch.setattr("nz_mcp.catalog.views.open_connection", lambda *_a, **_k: connection)
+    monkeypatch.setattr(
+        "nz_mcp.catalog.views.resolve_query",
+        lambda _i, _p: "SELECT DEFINITION FROM <BD>.._V_VIEW WHERE A=1",
+    )
+
+    assert "CREATE VIEW X" in get_view_ddl(_profile(), database="DB", schema="S", view="X")
+
+
+def test_get_view_ddl_raises_when_no_row(monkeypatch: pytest.MonkeyPatch) -> None:
+    cursor = _FakeDdlCursor(one=None)
+    connection = _FakeDdlConnection(cursor)
+    monkeypatch.setattr("nz_mcp.catalog.views.get_password", lambda _n: "pw")
+    monkeypatch.setattr("nz_mcp.catalog.views.open_connection", lambda *_a, **_k: connection)
+    monkeypatch.setattr(
+        "nz_mcp.catalog.views.resolve_query",
+        lambda _i, _p: "SELECT DEFINITION FROM <BD>.._V_VIEW WHERE 1=0",
+    )
+
+    with pytest.raises(NetezzaError) as exc:
+        get_view_ddl(_profile(), database="DB", schema="S", view="MISSING")
+
+    assert "No view definition" in exc.value.context["detail"]
+
+
+def test_get_view_ddl_wraps_driver_errors(monkeypatch: pytest.MonkeyPatch) -> None:
+    class _Boom(_FakeDdlCursor):
+        def execute(self, sql: str, params: tuple[str, str]) -> None:
+            _ = (sql, params)
+            raise RuntimeError("driver boom")
+
+    cursor = _Boom(one=None)
+    connection = _FakeDdlConnection(cursor)
+    monkeypatch.setattr("nz_mcp.catalog.views.get_password", lambda _n: "pwd-123")
+    monkeypatch.setattr("nz_mcp.catalog.views.open_connection", lambda *_a, **_k: connection)
+    monkeypatch.setattr(
+        "nz_mcp.catalog.views.resolve_query",
+        lambda _i, _p: "SELECT DEFINITION FROM <BD>.._V_VIEW",
+    )
+
+    with pytest.raises(NetezzaError) as exc:
+        get_view_ddl(_profile(), database="DB", schema="S", view="V")
+
+    assert "driver boom" in exc.value.context["detail"]
+    assert "pwd-123" not in exc.value.context["detail"]
+
+
+def test_get_view_ddl_rejects_dict_without_definition(monkeypatch: pytest.MonkeyPatch) -> None:
+    cursor = _FakeDdlCursor(one={"OWNER": "X"})
+    connection = _FakeDdlConnection(cursor)
+    monkeypatch.setattr("nz_mcp.catalog.views.get_password", lambda _n: "pw")
+    monkeypatch.setattr("nz_mcp.catalog.views.open_connection", lambda *_a, **_k: connection)
+    monkeypatch.setattr(
+        "nz_mcp.catalog.views.resolve_query",
+        lambda _i, _p: "SELECT 1 FROM <BD>.._V_VIEW",
+    )
+
+    with pytest.raises(NetezzaError) as exc:
+        get_view_ddl(_profile(), database="D", schema="S", view="V")
+
+    assert "DEFINITION" in exc.value.context["detail"]

--- a/tests/unit/test_tools_views.py
+++ b/tests/unit/test_tools_views.py
@@ -1,0 +1,99 @@
+"""Tests for view catalog MCP tools."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from nz_mcp.errors import NetezzaError
+from nz_mcp.tools.views import (
+    GetViewDdlInput,
+    ListViewsInput,
+    nz_get_view_ddl,
+    nz_list_views,
+)
+
+
+def test_list_views_input_accepts_wire_schema_key() -> None:
+    parsed = ListViewsInput.model_validate({"database": "DEV", "schema": "PUBLIC"})
+    assert parsed.view_schema == "PUBLIC"
+
+
+def test_get_view_ddl_input_accepts_wire_keys() -> None:
+    parsed = GetViewDdlInput.model_validate(
+        {"database": "DEV", "schema": "PUBLIC", "view": "V_X"},
+    )
+    assert parsed.view_schema == "PUBLIC"
+    assert parsed.view == "V_X"
+
+
+def test_nz_list_views_happy_path(monkeypatch: pytest.MonkeyPatch, two_profiles: Path) -> None:
+    def _fake_list_views(
+        _profile: object,
+        database: str,
+        schema: str,
+        pattern: str | None = None,
+    ) -> list[dict[str, str]]:
+        assert database == "DEV"
+        assert schema == "PUBLIC"
+        assert pattern == "V%"
+        return [{"name": "V1", "owner": "ADMIN"}]
+
+    monkeypatch.setattr("nz_mcp.tools.views.list_views", _fake_list_views)
+    out = nz_list_views(
+        ListViewsInput(database="DEV", view_schema="PUBLIC", pattern="V%"),
+        config_path=two_profiles,
+    )
+    assert len(out.views) == 1
+    assert out.views[0].name == "V1"
+    assert out.views[0].owner == "ADMIN"
+
+
+def test_nz_list_views_propagates_errors(
+    monkeypatch: pytest.MonkeyPatch, two_profiles: Path
+) -> None:
+    def _raise(*_a: object, **_k: object) -> list[dict[str, str]]:
+        raise NetezzaError(operation="list_views", detail="denied")
+
+    monkeypatch.setattr("nz_mcp.tools.views.list_views", _raise)
+
+    with pytest.raises(NetezzaError):
+        nz_list_views(
+            ListViewsInput(database="DEV", view_schema="PUBLIC"), config_path=two_profiles
+        )
+
+
+def test_nz_get_view_ddl_happy_path(monkeypatch: pytest.MonkeyPatch, two_profiles: Path) -> None:
+    def _fake_get_view_ddl(
+        _profile: object,
+        database: str,
+        schema: str,
+        view: str,
+    ) -> str:
+        assert database == "DEV"
+        assert schema == "PUBLIC"
+        assert view == "VW_A"
+        return "CREATE VIEW PUBLIC.VW_A AS SELECT 1"
+
+    monkeypatch.setattr("nz_mcp.tools.views.get_view_ddl", _fake_get_view_ddl)
+    out = nz_get_view_ddl(
+        GetViewDdlInput(database="DEV", view_schema="PUBLIC", view="VW_A"),
+        config_path=two_profiles,
+    )
+    assert out.ddl.startswith("CREATE VIEW")
+
+
+def test_nz_get_view_ddl_propagates_errors(
+    monkeypatch: pytest.MonkeyPatch, two_profiles: Path
+) -> None:
+    def _raise(*_a: object, **_k: object) -> str:
+        raise NetezzaError(operation="get_view_ddl", detail="missing")
+
+    monkeypatch.setattr("nz_mcp.tools.views.get_view_ddl", _raise)
+
+    with pytest.raises(NetezzaError):
+        nz_get_view_ddl(
+            GetViewDdlInput(database="DEV", view_schema="PUBLIC", view="X"),
+            config_path=two_profiles,
+        )


### PR DESCRIPTION
## ¿Qué cambia?
Implementa dos herramientas de solo lectura sobre `_v_view`: listar vistas en un schema y obtener el DDL `CREATE VIEW`, reutilizando `LIST_VIEWS` / `GET_VIEW_DDL`, `resolve_query`, `render_cross_db` y sanitización de errores como en tablas/schemas.

## Issue relacionado
Closes #42

## Acción según AGENTS.md
- **Ruta (keywords)**: nueva tool, catálogo, vista, DDL view
- **Docs leídos**:
  - `docs/architecture/tools-contract.md`
  - `docs/actions/add-tool.md`
  - `AGENTS.md`
- **Rol asumido**: Backend Developer + Data Engineer

## Archivos esperados (según el issue)
- `src/nz_mcp/catalog/views.py`
- `src/nz_mcp/tools/views.py`
- `src/nz_mcp/tools/__init__.py`
- `tests/unit/test_catalog_views.py`
- `tests/unit/test_tools_views.py`
- `tests/integration/test_real_views.py` (opcional)
- `tests/contract/test_mcp_tool_schemas.py`
- `CHANGELOG.md`

Sin archivos extra no listados.

## Auditoría pre-merge — 7 dimensiones
> Marca todas las casillas. Bloqueantes sin marcar = no merge.
> Detalle: docs/standards/pr-audit.md

### 1. Contrato y compatibilidad
- [x] Catálogo / tools ya alineados con `tools-contract.md` §10–11 (sin cambiar el doc en este PR).
- [x] `CHANGELOG.md` con entrada bilingüe en `Added` para **dos** herramientas nuevas.
- [x] Sin breaking change.

### 2. Seguridad
- [x] SQL parametrizado; valores de usuario no concatenados en SQL.
- [x] Errores del driver en `detail` pasan por `sanitize(..., known_secrets={password})`.
- [x] No tocado `sql_guard.py` ni `auth.py` en este PR.

### 3. Mantenibilidad y diseño
- [x] Alcance acotado al issue (vistas / DDL).
- [x] Sin dependencias nuevas ni ADR.

### 4. Tests
- [x] Tests unit catálogo (list + DDL, errores, shape de filas).
- [x] Tests unit ambas tools + contrato `EXPECTED_V010A0`.
- [x] Integración opcional marcada `@pytest.mark.integration`.

### 5. Tipado y estilo
- [x] `ruff check` / `ruff format` verdes en CI.
- [x] `mypy --strict` verde en CI.
- [x] Except defensivo catalog con `# noqa: BLE001, RUF100` como en otros módulos de catálogo.

### 6. Documentación
- [x] `CHANGELOG.md` bilingüe (dos herramientas).

### 7. Idioma y forma
- [x] Título y commit en español, conventional.
- [x] Código y comentarios en inglés.

## Validación humana requerida
- [ ] Sí — explicar por qué:
- [x] No

## Notas para el auditor
- Campos `view_schema` con `alias="schema"` en los modelos Pydantic para no sombrear `BaseModel.schema`; el JSON del MCP sigue usando la clave `schema`.
