### PR TITLE
feat(tools): implementa nz_describe_table (columnas, distribución, PK, FK)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ Cada entrada se documenta en **español** y **english**.
 - EN: driver error messages in `open_connection`, `list_databases`, and `probe-catalog` are passed through `sanitize()` with `known_secrets` so passwords are not leaked in MCP-exposed `detail` fields.
 
 ### Added
+- ES: tool `nz_describe_table` para metadata de tabla (columnas, distribución, PK, FK) vía catálogo `_v_*`.
+- EN: `nz_describe_table` tool for table metadata (columns, distribution, PK, FK) via `_v_*` catalog views.
 - ES: tool `nz_get_view_ddl` para obtener el DDL `CREATE VIEW` desde `_v_view` (cross-database).
 - EN: `nz_get_view_ddl` tool to fetch `CREATE VIEW` DDL from `_v_view` (cross-database).
 - ES: tool `nz_list_views` para listar vistas en un schema vía catálogo `_v_view` (cross-database).

--- a/src/nz_mcp/catalog/tables.py
+++ b/src/nz_mcp/catalog/tables.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from collections import defaultdict
 from contextlib import closing
 from typing import Any, Final, Protocol, cast
 
@@ -10,11 +11,29 @@ from nz_mcp.catalog.identifier import render_cross_db
 from nz_mcp.catalog.resolver import resolve_query
 from nz_mcp.config import Profile
 from nz_mcp.connection import open_connection
-from nz_mcp.errors import NetezzaError
+from nz_mcp.errors import NetezzaError, ObjectNotFoundError
 from nz_mcp.logging_utils import sanitize
 
 _TABLE_ROW_MIN_ITEMS: Final[int] = 2
 _TABLE_KIND: Final[str] = "TABLE"
+_DIST_ROW_MIN: Final[int] = 2
+_COL_TUPLE_MIN: Final[int] = 4
+_PK_TUPLE_MIN: Final[int] = 3
+_FK_PK_MIN: Final[int] = 4
+_FK_SCHEMA_MIN: Final[int] = 5
+_FK_REL_MIN: Final[int] = 6
+_FK_ATT_MIN: Final[int] = 7
+
+
+class _DescribeCursorLike(Protocol):
+    def execute(self, sql: str, params: tuple[str, str]) -> None: ...
+    def fetchall(self) -> list[Any]: ...
+    def close(self) -> None: ...
+
+
+class _DescribeConnectionLike(Protocol):
+    def cursor(self) -> _DescribeCursorLike: ...
+    def close(self) -> None: ...
 
 
 class _CursorLike(Protocol):
@@ -78,3 +97,269 @@ def _row_to_table(row: Any) -> dict[str, str]:
     if isinstance(row, tuple) and len(row) >= _TABLE_ROW_MIN_ITEMS:
         return {"name": str(row[0]), "kind": _TABLE_KIND}
     raise NetezzaError(operation="list_tables", detail="Unexpected row shape from _v_table")
+
+
+def describe_table(
+    profile: Profile,
+    database: str,
+    schema: str,
+    table: str,
+) -> dict[str, Any]:
+    """Return columns, distribution, PK, and FK metadata for one base table via catalog views."""
+    params: tuple[str, str] = (schema, table)
+    password = get_password(profile.name)
+    connection = cast(_DescribeConnectionLike, open_connection(profile, password))
+    try:
+        with closing(connection.cursor()) as cursor:
+            col_sql = render_cross_db(
+                resolve_query("describe_table_columns", profile),
+                database=database,
+            )
+            cursor.execute(col_sql, params)
+            column_rows = cursor.fetchall()
+            if not column_rows:
+                raise ObjectNotFoundError(
+                    detail=(
+                        "No columns returned for this table — table may not exist "
+                        f"or may not be visible (database={database!r}, schema={schema!r}, "
+                        f"table={table!r})."
+                    ),
+                )
+
+            dist_sql = render_cross_db(
+                resolve_query("describe_table_distribution", profile),
+                database=database,
+            )
+            cursor.execute(dist_sql, params)
+            dist_rows = cursor.fetchall()
+
+            pk_sql = render_cross_db(
+                resolve_query("describe_table_pk", profile),
+                database=database,
+            )
+            cursor.execute(pk_sql, params)
+            pk_rows = cursor.fetchall()
+
+            fk_sql = render_cross_db(
+                resolve_query("describe_table_fk", profile),
+                database=database,
+            )
+            cursor.execute(fk_sql, params)
+            fk_rows = cursor.fetchall()
+    except ObjectNotFoundError:
+        raise
+    except Exception as exc:  # noqa: BLE001, RUF100
+        raise NetezzaError(
+            operation="describe_table",
+            database=database,
+            detail=sanitize(str(exc), known_secrets={password}),
+        ) from exc
+    finally:
+        connection.close()
+
+    dist = _distribution_from_rows(dist_rows)
+    return {
+        "name": table.upper(),
+        "kind": _TABLE_KIND,
+        "columns": [_column_descriptor(r) for r in column_rows],
+        "distribution": dist,
+        "organized_on": [],
+        "primary_key": _primary_key_columns(pk_rows),
+        "foreign_keys": _foreign_keys_payload(fk_rows),
+    }
+
+
+def _distribution_from_rows(rows: list[Any]) -> dict[str, Any]:
+    if not rows:
+        return {"type": "RANDOM", "columns": []}
+    pairs: list[tuple[int, str]] = []
+    for row in rows:
+        attname, seq = _distribution_pair(row)
+        pairs.append((seq, attname))
+    pairs.sort(key=lambda p: p[0])
+    return {"type": "HASH", "columns": [p[1] for p in pairs]}
+
+
+def _distribution_pair(row: Any) -> tuple[str, int]:
+    if isinstance(row, dict):
+        att = row.get("ATTNAME")
+        seq = row.get("DISTSEQNO")
+        if att is None or seq is None:
+            raise NetezzaError(
+                operation="describe_table",
+                detail="Distribution row must include ATTNAME and DISTSEQNO.",
+            )
+        return str(att), int(seq)
+    if isinstance(row, tuple) and len(row) >= _DIST_ROW_MIN:
+        return str(row[0]), int(row[1])
+    raise NetezzaError(operation="describe_table", detail="Unexpected distribution row shape.")
+
+
+def _column_descriptor(row: Any) -> dict[str, Any]:
+    if isinstance(row, dict):
+        name = row.get("COLUMN_NAME")
+        dtype = row.get("DATA_TYPE")
+        not_null = row.get("NOT_NULL")
+        default = row.get("DEFAULT_VALUE")
+        if name is None or dtype is None or not_null is None:
+            raise NetezzaError(
+                operation="describe_table",
+                detail="Column row must include COLUMN_NAME, DATA_TYPE, NOT_NULL.",
+            )
+        return {
+            "name": str(name),
+            "type": str(dtype),
+            "nullable": not _is_not_null(not_null),
+            "default": None if default is None else str(default),
+        }
+    if isinstance(row, tuple) and len(row) >= _COL_TUPLE_MIN:
+        default_val = row[3]
+        return {
+            "name": str(row[0]),
+            "type": str(row[1]),
+            "nullable": not _is_not_null(row[2]),
+            "default": None if default_val is None else str(default_val),
+        }
+    raise NetezzaError(operation="describe_table", detail="Unexpected column row shape.")
+
+
+def _is_not_null(cell: Any) -> bool:
+    if isinstance(cell, bool):
+        return cell
+    if isinstance(cell, (int, float)):
+        return cell != 0
+    lowered = str(cell).lower()
+    return lowered in ("t", "true", "1", "yes")
+
+
+def _primary_key_columns(rows: list[Any]) -> list[str]:
+    if not rows:
+        return []
+    grouped: defaultdict[str, list[tuple[int, str]]] = defaultdict(list)
+    for row in rows:
+        cname, attname, seq = _pk_triplet(row)
+        grouped[cname].append((seq, attname))
+    chosen = sorted(grouped.keys())[0]
+    ordered = sorted(grouped[chosen], key=lambda p: p[0])
+    return [p[1] for p in ordered]
+
+
+def _pk_triplet(row: Any) -> tuple[str, str, int]:
+    if isinstance(row, dict):
+        c = row.get("CONSTRAINTNAME")
+        a = row.get("ATTNAME")
+        s = row.get("CONSEQ")
+        if c is None or a is None or s is None:
+            raise NetezzaError(
+                operation="describe_table",
+                detail="Primary key row must include CONSTRAINTNAME, ATTNAME, CONSEQ.",
+            )
+        return str(c), str(a), int(s)
+    if isinstance(row, tuple) and len(row) >= _PK_TUPLE_MIN:
+        return str(row[0]), str(row[1]), int(row[2])
+    raise NetezzaError(operation="describe_table", detail="Unexpected primary key row shape.")
+
+
+def _foreign_keys_payload(rows: list[Any]) -> list[dict[str, Any]]:
+    if not rows:
+        return []
+    grouped: defaultdict[str, list[Any]] = defaultdict(list)
+    for row in rows:
+        grouped[_fk_constraint_name(row)].append(row)
+    out: list[dict[str, Any]] = []
+    for cname in sorted(grouped.keys()):
+        group_rows = sorted(grouped[cname], key=_fk_conseq)
+        first = group_rows[0]
+        out.append(
+            {
+                "name": cname,
+                "columns": [_fk_local_column(r) for r in group_rows],
+                "references": {
+                    "database": _fk_ref_database(first),
+                    "schema": _fk_ref_schema(first),
+                    "table": _fk_ref_table(first),
+                    "columns": [_fk_ref_column(r) for r in group_rows],
+                },
+            }
+        )
+    return out
+
+
+def _fk_constraint_name(row: Any) -> str:
+    if isinstance(row, dict):
+        v = row.get("CONSTRAINTNAME")
+        if v is None:
+            raise NetezzaError(operation="describe_table", detail="FK row missing CONSTRAINTNAME.")
+        return str(v)
+    if isinstance(row, tuple) and len(row) >= 1:
+        return str(row[0])
+    raise NetezzaError(operation="describe_table", detail="Unexpected FK row shape.")
+
+
+def _fk_conseq(row: Any) -> int:
+    if isinstance(row, dict):
+        s = row.get("CONSEQ")
+        if s is None:
+            raise NetezzaError(operation="describe_table", detail="FK row missing CONSEQ.")
+        return int(s)
+    if isinstance(row, tuple) and len(row) >= _PK_TUPLE_MIN:
+        return int(row[2])
+    raise NetezzaError(operation="describe_table", detail="Unexpected FK row shape.")
+
+
+def _fk_local_column(row: Any) -> str:
+    if isinstance(row, dict):
+        v = row.get("ATTNAME")
+        if v is None:
+            raise NetezzaError(operation="describe_table", detail="FK row missing ATTNAME.")
+        return str(v)
+    if isinstance(row, tuple) and len(row) >= _DIST_ROW_MIN:
+        return str(row[1])
+    raise NetezzaError(operation="describe_table", detail="Unexpected FK row shape.")
+
+
+def _fk_ref_database(row: Any) -> str | None:
+    key = "PKDATABASE"
+    if isinstance(row, dict):
+        val = row.get(key)
+        return None if val is None else str(val)
+    if isinstance(row, tuple) and len(row) >= _FK_PK_MIN:
+        val = row[3]
+        return None if val is None else str(val)
+    raise NetezzaError(operation="describe_table", detail="Unexpected FK row shape.")
+
+
+def _fk_ref_schema(row: Any) -> str:
+    key = "PKSCHEMA"
+    if isinstance(row, dict):
+        v = row.get(key)
+        if v is None:
+            raise NetezzaError(operation="describe_table", detail="FK row missing PKSCHEMA.")
+        return str(v)
+    if isinstance(row, tuple) and len(row) >= _FK_SCHEMA_MIN:
+        return str(row[4])
+    raise NetezzaError(operation="describe_table", detail="Unexpected FK row shape.")
+
+
+def _fk_ref_table(row: Any) -> str:
+    key = "PKRELATION"
+    if isinstance(row, dict):
+        v = row.get(key)
+        if v is None:
+            raise NetezzaError(operation="describe_table", detail="FK row missing PKRELATION.")
+        return str(v)
+    if isinstance(row, tuple) and len(row) >= _FK_REL_MIN:
+        return str(row[5])
+    raise NetezzaError(operation="describe_table", detail="Unexpected FK row shape.")
+
+
+def _fk_ref_column(row: Any) -> str:
+    key = "PKATTNAME"
+    if isinstance(row, dict):
+        v = row.get(key)
+        if v is None:
+            raise NetezzaError(operation="describe_table", detail="FK row missing PKATTNAME.")
+        return str(v)
+    if isinstance(row, tuple) and len(row) >= _FK_ATT_MIN:
+        return str(row[6])
+    raise NetezzaError(operation="describe_table", detail="Unexpected FK row shape.")

--- a/src/nz_mcp/server.py
+++ b/src/nz_mcp/server.py
@@ -70,7 +70,7 @@ def call_tool(
     except NzMcpError as exc:
         return _error_response(exc.code, **exc.context)
 
-    return {"result": result.model_dump(mode="json")}
+    return {"result": result.model_dump(mode="json", by_alias=True)}
 
 
 def _invoke(spec: ToolSpec, params: Any, *, config_path: Path | None) -> Any:

--- a/src/nz_mcp/tools/__init__.py
+++ b/src/nz_mcp/tools/__init__.py
@@ -7,6 +7,7 @@ from __future__ import annotations
 
 from nz_mcp.tools import (
     databases,  # noqa: F401  (registers database tools)
+    describe_table,  # noqa: F401  (registers nz_describe_table)
     schemas,  # noqa: F401  (registers schema tools)
     session,  # noqa: F401  (registers session tools)
     tables,  # noqa: F401  (registers table tools)

--- a/src/nz_mcp/tools/describe_table.py
+++ b/src/nz_mcp/tools/describe_table.py
@@ -1,0 +1,90 @@
+"""Describe base table metadata (columns, distribution, PK, FK) from Netezza catalogs."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Literal
+
+from pydantic import BaseModel, ConfigDict, Field
+
+from nz_mcp.catalog.tables import describe_table
+from nz_mcp.config import get_active_profile
+from nz_mcp.tools.registry import tool
+
+
+class DescribeTableInput(BaseModel):
+    model_config = ConfigDict(extra="forbid", populate_by_name=True)
+    database: str = Field(min_length=1, max_length=128)
+    table_schema: str = Field(
+        alias="schema",
+        min_length=1,
+        max_length=128,
+    )
+    table: str = Field(min_length=1, max_length=128)
+
+
+class ColumnDescriptor(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+    name: str
+    sql_type: str = Field(alias="type")
+    nullable: bool
+    default: str | None
+
+
+class DistributionBlock(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+    dist_type: Literal["HASH", "RANDOM"] = Field(alias="type")
+    columns: list[str]
+
+
+class ForeignKeyReferences(BaseModel):
+    model_config = ConfigDict(extra="forbid", populate_by_name=True)
+    database: str | None = None
+    ref_schema: str = Field(alias="schema")
+    ref_table: str = Field(alias="table")
+    columns: list[str]
+
+
+class ForeignKeyItem(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+    name: str
+    columns: list[str]
+    references: ForeignKeyReferences
+
+
+class DescribeTableOutput(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+    name: str
+    kind: Literal["TABLE"] = "TABLE"
+    columns: list[ColumnDescriptor]
+    distribution: DistributionBlock
+    organized_on: list[str] = Field(default_factory=list)
+    primary_key: list[str]
+    foreign_keys: list[ForeignKeyItem]
+
+
+@tool(
+    name="nz_describe_table",
+    description=(
+        "Describe Netezza table columns, primary key, foreign keys, and distribution "
+        "from system catalogs. Use before querying or sampling data. "
+        "Do not use for views or procedures."
+    ),
+    mode="read",
+    input_model=DescribeTableInput,
+    output_model=DescribeTableOutput,
+    annotations={"readOnlyHint": True, "idempotentHint": True, "openWorldHint": False},
+)
+def nz_describe_table(
+    params: DescribeTableInput,
+    *,
+    config_path: Path | None = None,
+) -> DescribeTableOutput:
+    profile = get_active_profile(path=config_path)
+    payload = describe_table(
+        profile,
+        database=params.database,
+        schema=params.table_schema,
+        table=params.table,
+    )
+    return DescribeTableOutput.model_validate(payload)

--- a/tests/contract/test_mcp_tool_schemas.py
+++ b/tests/contract/test_mcp_tool_schemas.py
@@ -9,6 +9,7 @@ from pathlib import Path
 
 import pytest
 
+from nz_mcp.errors import ObjectNotFoundError
 from nz_mcp.server import call_tool, list_tools
 from nz_mcp.tools.registry import TOOLS
 
@@ -70,6 +71,24 @@ def test_call_tool_happy_path(two_profiles: Path) -> None:
     out = call_tool("nz_current_profile", {}, config_path=two_profiles)
     assert "result" in out
     assert out["result"]["profile"] == "dev"
+
+
+@pytest.mark.contract
+def test_call_tool_describe_table_object_not_found(
+    two_profiles: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    def _raise(_profile: object, **_kwargs: object) -> dict[str, object]:
+        raise ObjectNotFoundError(detail="no such table")
+
+    monkeypatch.setattr("nz_mcp.tools.describe_table.describe_table", _raise)
+
+    out = call_tool(
+        "nz_describe_table",
+        {"database": "DEV", "schema": "PUBLIC", "table": "__missing__"},
+        config_path=two_profiles,
+    )
+    assert "error" in out
+    assert out["error"]["code"] == "OBJECT_NOT_FOUND"
 
 
 @pytest.mark.contract

--- a/tests/contract/test_mcp_tool_schemas.py
+++ b/tests/contract/test_mcp_tool_schemas.py
@@ -14,6 +14,7 @@ from nz_mcp.tools.registry import TOOLS
 
 EXPECTED_V010A0: set[str] = {
     "nz_current_profile",
+    "nz_describe_table",
     "nz_get_view_ddl",
     "nz_list_databases",
     "nz_list_schemas",

--- a/tests/integration/test_real_describe_table.py
+++ b/tests/integration/test_real_describe_table.py
@@ -1,0 +1,35 @@
+"""Optional integration test for ``nz_describe_table`` against real Netezza."""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+import pytest
+
+from nz_mcp.tools.describe_table import DescribeTableInput, nz_describe_table
+from nz_mcp.tools.tables import ListTablesInput, nz_list_tables
+
+
+@pytest.mark.integration
+def test_real_nz_describe_table() -> None:
+    if os.environ.get("NZ_MCP_RUN_INTEGRATION") != "1":
+        pytest.skip("Set NZ_MCP_RUN_INTEGRATION=1 to run integration tests against real Netezza")
+
+    config_override = os.environ.get("NZ_MCP_INTEGRATION_PROFILES")
+    config_path = Path(config_override) if config_override else None
+
+    tables_out = nz_list_tables(
+        ListTablesInput(database="DEV", table_schema="PUBLIC"),
+        config_path=config_path,
+    )
+    if not tables_out.tables:
+        pytest.skip("No tables in PUBLIC to describe")
+
+    first = tables_out.tables[0].name
+    out = nz_describe_table(
+        DescribeTableInput(database="DEV", table_schema="PUBLIC", table=first),
+        config_path=config_path,
+    )
+    assert out.kind == "TABLE"
+    assert isinstance(out.columns, list)

--- a/tests/unit/test_catalog_describe_table.py
+++ b/tests/unit/test_catalog_describe_table.py
@@ -1,0 +1,262 @@
+"""Unit tests for ``describe_table`` catalog orchestration."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+import nz_mcp.catalog.tables as tables_mod
+from nz_mcp.catalog.tables import describe_table
+from nz_mcp.config import Profile
+from nz_mcp.errors import NetezzaError, ObjectNotFoundError
+
+
+class _RoutingCursor:
+    """Return rows based on which catalog view the SQL targets."""
+
+    def __init__(self, buckets: dict[str, Any]) -> None:
+        self._buckets = buckets
+        self.executed_sql: list[str] = []
+        self.executed_params: list[tuple[str, str]] = []
+        self.closed = False
+
+    def execute(self, sql: str, params: tuple[str, str]) -> None:
+        self.executed_sql.append(sql)
+        self.executed_params.append(params)
+
+    def fetchall(self) -> list[object]:
+        sql_l = self.executed_sql[-1].lower()
+        if "_v_relation_column" in sql_l:
+            return list(self._buckets.get("columns", []))
+        if "_v_table_dist_map" in sql_l:
+            return list(self._buckets.get("dist", []))
+        if "contype = 'f'" in sql_l:
+            return list(self._buckets.get("fk", []))
+        if "contype = 'p'" in sql_l:
+            return list(self._buckets.get("pk", []))
+        raise AssertionError(f"unexpected SQL bucket: {sql_l[:120]!r}")
+
+    def close(self) -> None:
+        self.closed = True
+
+
+class _FakeConn:
+    def __init__(self, cursor: _RoutingCursor) -> None:
+        self._cursor = cursor
+        self.closed = False
+
+    def cursor(self) -> _RoutingCursor:
+        return self._cursor
+
+    def close(self) -> None:
+        self.closed = True
+
+
+def _profile() -> Profile:
+    return Profile(
+        name="dev",
+        host="h.example.com",
+        port=5480,
+        database="DEV",
+        user="u",
+        mode="read",
+    )
+
+
+def test_describe_table_one_connection_four_queries(monkeypatch: pytest.MonkeyPatch) -> None:
+    buckets = {
+        "columns": [
+            ("ID", "INTEGER", True, None, 1),
+            ("NM", "VARCHAR(10)", False, None, 2),
+        ],
+        "dist": [("ID", 1)],
+        "pk": [("pk_cust", "ID", 1)],
+        "fk": [],
+    }
+    cursor = _RoutingCursor(buckets)
+    conn = _FakeConn(cursor)
+    monkeypatch.setattr(tables_mod, "get_password", lambda _n: "pw")
+    monkeypatch.setattr(tables_mod, "open_connection", lambda *_a, **_k: conn)
+    monkeypatch.setattr(
+        tables_mod,
+        "resolve_query",
+        lambda qid, _p: {
+            "describe_table_columns": "SELECT ... FROM <BD>.._V_RELATION_COLUMN WHERE ...",
+            "describe_table_distribution": "SELECT ... FROM <BD>.._V_TABLE_DIST_MAP WHERE ...",
+            "describe_table_pk": (
+                "SELECT ... FROM <BD>.._V_RELATION_KEYDATA WHERE ... AND CONTYPE = 'p' ..."
+            ),
+            "describe_table_fk": (
+                "SELECT ... FROM <BD>.._V_RELATION_KEYDATA WHERE ... AND CONTYPE = 'f' ..."
+            ),
+        }[qid],
+    )
+
+    out = describe_table(_profile(), database="DB", schema="PUBLIC", table="T")
+
+    assert len(cursor.executed_sql) == 4
+    assert all(p == ("PUBLIC", "T") for p in cursor.executed_params)
+    assert out["name"] == "T"
+    assert out["kind"] == "TABLE"
+    assert len(out["columns"]) == 2
+    assert out["columns"][0]["type"] == "INTEGER"
+    assert out["columns"][0]["nullable"] is False
+    assert out["distribution"] == {"type": "HASH", "columns": ["ID"]}
+    assert out["organized_on"] == []
+    assert out["primary_key"] == ["ID"]
+    assert out["foreign_keys"] == []
+    assert conn.closed is True
+
+
+def test_describe_table_random_distribution(monkeypatch: pytest.MonkeyPatch) -> None:
+    buckets = {
+        "columns": [("X", "INT", True, None, 1)],
+        "dist": [],
+        "pk": [],
+        "fk": [],
+    }
+    cursor = _RoutingCursor(buckets)
+    monkeypatch.setattr(tables_mod, "get_password", lambda _n: "pw")
+    monkeypatch.setattr(tables_mod, "open_connection", lambda *_a, **_k: _FakeConn(cursor))
+    monkeypatch.setattr(
+        tables_mod,
+        "resolve_query",
+        lambda qid, _p: {
+            "describe_table_columns": "_V_RELATION_COLUMN",
+            "describe_table_distribution": "_V_TABLE_DIST_MAP",
+            "describe_table_pk": "CONTYPE = 'p'",
+            "describe_table_fk": "CONTYPE = 'f'",
+        }[qid],
+    )
+
+    out = describe_table(_profile(), database="DB", schema="S", table="T")
+    assert out["distribution"] == {"type": "RANDOM", "columns": []}
+
+
+def test_describe_table_foreign_key_cross_database(monkeypatch: pytest.MonkeyPatch) -> None:
+    buckets = {
+        "columns": [("OID", "INT", True, None, 1)],
+        "dist": [],
+        "pk": [],
+        "fk": [
+            (
+                "fk_ord",
+                "ORDER_ID",
+                1,
+                "OTHERDB",
+                "ORD",
+                "ORDERS",
+                "ID",
+                "a",
+                "b",
+            ),
+            (
+                "fk_ord",
+                "LINE_NO",
+                2,
+                "OTHERDB",
+                "ORD",
+                "ORDERS",
+                "LINENO",
+                "a",
+                "b",
+            ),
+        ],
+    }
+    cursor = _RoutingCursor(buckets)
+    monkeypatch.setattr(tables_mod, "get_password", lambda _n: "pw")
+    monkeypatch.setattr(tables_mod, "open_connection", lambda *_a, **_k: _FakeConn(cursor))
+    monkeypatch.setattr(
+        tables_mod,
+        "resolve_query",
+        lambda qid, _p: {
+            "describe_table_columns": "_V_RELATION_COLUMN",
+            "describe_table_distribution": "_V_TABLE_DIST_MAP",
+            "describe_table_pk": "CONTYPE = 'p'",
+            "describe_table_fk": "CONTYPE = 'f'",
+        }[qid],
+    )
+
+    out = describe_table(_profile(), database="DB", schema="S", table="LINES")
+    assert len(out["foreign_keys"]) == 1
+    fk = out["foreign_keys"][0]
+    assert fk["name"] == "fk_ord"
+    assert fk["columns"] == ["ORDER_ID", "LINE_NO"]
+    assert fk["references"]["database"] == "OTHERDB"
+    assert fk["references"]["schema"] == "ORD"
+    assert fk["references"]["table"] == "ORDERS"
+    assert fk["references"]["columns"] == ["ID", "LINENO"]
+
+
+def test_describe_table_raises_when_no_columns(monkeypatch: pytest.MonkeyPatch) -> None:
+    buckets: dict[str, Any] = {"columns": [], "dist": [], "pk": [], "fk": []}
+    cursor = _RoutingCursor(buckets)
+    monkeypatch.setattr(tables_mod, "get_password", lambda _n: "pw")
+    monkeypatch.setattr(tables_mod, "open_connection", lambda *_a, **_k: _FakeConn(cursor))
+    monkeypatch.setattr(
+        tables_mod,
+        "resolve_query",
+        lambda qid, _p: "_V_RELATION_COLUMN" if qid == "describe_table_columns" else "x",
+    )
+
+    with pytest.raises(ObjectNotFoundError) as exc:
+        describe_table(_profile(), database="DB", schema="S", table="MISSING")
+
+    assert exc.value.code == "OBJECT_NOT_FOUND"
+
+
+def test_describe_table_wraps_driver_errors(monkeypatch: pytest.MonkeyPatch) -> None:
+    class _BoomCursor(_RoutingCursor):
+        def fetchall(self) -> list[object]:
+            raise RuntimeError("boom")
+
+    cursor = _BoomCursor(
+        {
+            "columns": [("ID", "INT", True, None, 1)],
+            "dist": [],
+            "pk": [],
+            "fk": [],
+        },
+    )
+    monkeypatch.setattr(tables_mod, "get_password", lambda _n: "secret")
+    monkeypatch.setattr(tables_mod, "open_connection", lambda *_a, **_k: _FakeConn(cursor))
+    monkeypatch.setattr(
+        tables_mod,
+        "resolve_query",
+        lambda qid, _p: "_V_RELATION_COLUMN",
+    )
+
+    with pytest.raises(NetezzaError) as exc:
+        describe_table(_profile(), database="DB", schema="S", table="T")
+
+    assert "boom" in exc.value.context["detail"]
+    assert "secret" not in exc.value.context["detail"]
+
+
+def test_describe_table_routing_detects_pk_query(monkeypatch: pytest.MonkeyPatch) -> None:
+    """PK query uses _V_RELATION_KEYDATA and CONTYPE P; ensure we route before FK."""
+    buckets = {
+        "columns": [("ID", "INT", True, None, 1)],
+        "dist": [],
+        "pk": [("pk1", "ID", 1)],
+        "fk": [],
+    }
+    cursor = _RoutingCursor(buckets)
+    monkeypatch.setattr(tables_mod, "get_password", lambda _n: "pw")
+    monkeypatch.setattr(tables_mod, "open_connection", lambda *_a, **_k: _FakeConn(cursor))
+    monkeypatch.setattr(
+        tables_mod,
+        "resolve_query",
+        lambda qid, _p: {
+            "describe_table_columns": "_V_RELATION_COLUMN",
+            "describe_table_distribution": "_V_TABLE_DIST_MAP",
+            "describe_table_pk": ("FROM <BD>.._V_RELATION_KEYDATA WHERE ... CONTYPE = 'p' ..."),
+            "describe_table_fk": ("FROM <BD>.._V_RELATION_KEYDATA WHERE ... CONTYPE = 'f' ..."),
+        }[qid],
+    )
+
+    describe_table(_profile(), database="DB", schema="S", table="T")
+    joined = "\n".join(cursor.executed_sql).lower()
+    assert "contype = 'p'" in joined
+    assert "contype = 'f'" in joined

--- a/tests/unit/test_catalog_describe_table.py
+++ b/tests/unit/test_catalog_describe_table.py
@@ -260,3 +260,256 @@ def test_describe_table_routing_detects_pk_query(monkeypatch: pytest.MonkeyPatch
     joined = "\n".join(cursor.executed_sql).lower()
     assert "contype = 'p'" in joined
     assert "contype = 'f'" in joined
+
+
+def test_describe_table_dict_shaped_catalog_rows(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Cover dict-row parsing paths (nzpy-style keys) for all four queries."""
+    buckets = {
+        "columns": [
+            {
+                "COLUMN_NAME": "ID",
+                "DATA_TYPE": "INTEGER",
+                "NOT_NULL": True,
+                "DEFAULT_VALUE": None,
+            },
+            {
+                "COLUMN_NAME": "NM",
+                "DATA_TYPE": "VARCHAR(5)",
+                "NOT_NULL": False,
+                "DEFAULT_VALUE": "'x'",
+            },
+        ],
+        "dist": [{"ATTNAME": "ID", "DISTSEQNO": 1}],
+        "pk": [{"CONSTRAINTNAME": "pk_t", "ATTNAME": "ID", "CONSEQ": 1}],
+        "fk": [
+            {
+                "CONSTRAINTNAME": "fk_ref",
+                "ATTNAME": "NM",
+                "CONSEQ": 1,
+                "PKDATABASE": None,
+                "PKSCHEMA": "REF",
+                "PKRELATION": "T2",
+                "PKATTNAME": "RID",
+                "DEL_TYPE": "a",
+                "UPDT_TYPE": "b",
+            },
+        ],
+    }
+    cursor = _RoutingCursor(buckets)
+    monkeypatch.setattr(tables_mod, "get_password", lambda _n: "pw")
+    monkeypatch.setattr(tables_mod, "open_connection", lambda *_a, **_k: _FakeConn(cursor))
+    monkeypatch.setattr(
+        tables_mod,
+        "resolve_query",
+        lambda qid, _p: {
+            "describe_table_columns": "_V_RELATION_COLUMN",
+            "describe_table_distribution": "_V_TABLE_DIST_MAP",
+            "describe_table_pk": "CONTYPE = 'p'",
+            "describe_table_fk": "CONTYPE = 'f'",
+        }[qid],
+    )
+
+    out = describe_table(_profile(), database="DB", schema="PUBLIC", table="t")
+
+    assert out["distribution"]["type"] == "HASH"
+    assert out["columns"][1]["nullable"] is True
+    assert out["columns"][1]["default"] == "'x'"
+    assert out["foreign_keys"][0]["references"]["database"] is None
+    assert out["foreign_keys"][0]["references"]["schema"] == "REF"
+
+
+def test_describe_table_pk_lexicographic_constraint_choice(monkeypatch: pytest.MonkeyPatch) -> None:
+    buckets = {
+        "columns": [("ID", "INT", True, None, 1)],
+        "dist": [],
+        "pk": [
+            ("ZPK", "ZCOL", 1),
+            ("APK", "ACOL", 1),
+        ],
+        "fk": [],
+    }
+    cursor = _RoutingCursor(buckets)
+    monkeypatch.setattr(tables_mod, "get_password", lambda _n: "pw")
+    monkeypatch.setattr(tables_mod, "open_connection", lambda *_a, **_k: _FakeConn(cursor))
+    monkeypatch.setattr(
+        tables_mod,
+        "resolve_query",
+        lambda qid, _p: {
+            "describe_table_columns": "_V_RELATION_COLUMN",
+            "describe_table_distribution": "_V_TABLE_DIST_MAP",
+            "describe_table_pk": "CONTYPE = 'p'",
+            "describe_table_fk": "CONTYPE = 'f'",
+        }[qid],
+    )
+
+    out = describe_table(_profile(), database="DB", schema="S", table="T")
+    assert out["primary_key"] == ["ACOL"]
+
+
+def test_describe_table_distribution_bad_dict_raises(monkeypatch: pytest.MonkeyPatch) -> None:
+    buckets = {
+        "columns": [("ID", "INT", True, None, 1)],
+        "dist": [{"DISTSEQNO": 1}],
+        "pk": [],
+        "fk": [],
+    }
+    cursor = _RoutingCursor(buckets)
+    monkeypatch.setattr(tables_mod, "get_password", lambda _n: "pw")
+    monkeypatch.setattr(tables_mod, "open_connection", lambda *_a, **_k: _FakeConn(cursor))
+    monkeypatch.setattr(
+        tables_mod,
+        "resolve_query",
+        lambda qid, _p: {
+            "describe_table_columns": "_V_RELATION_COLUMN",
+            "describe_table_distribution": "_V_TABLE_DIST_MAP",
+            "describe_table_pk": "CONTYPE = 'p'",
+            "describe_table_fk": "CONTYPE = 'f'",
+        }[qid],
+    )
+
+    with pytest.raises(NetezzaError) as exc:
+        describe_table(_profile(), database="DB", schema="S", table="T")
+
+    assert "ATTNAME" in exc.value.context["detail"]
+
+
+def test_describe_table_column_bad_dict_raises(monkeypatch: pytest.MonkeyPatch) -> None:
+    buckets = {
+        "columns": [{"COLUMN_NAME": "ID", "NOT_NULL": True}],
+        "dist": [],
+        "pk": [],
+        "fk": [],
+    }
+    cursor = _RoutingCursor(buckets)
+    monkeypatch.setattr(tables_mod, "get_password", lambda _n: "pw")
+    monkeypatch.setattr(tables_mod, "open_connection", lambda *_a, **_k: _FakeConn(cursor))
+    monkeypatch.setattr(
+        tables_mod,
+        "resolve_query",
+        lambda qid, _p: {
+            "describe_table_columns": "_V_RELATION_COLUMN",
+            "describe_table_distribution": "_V_TABLE_DIST_MAP",
+            "describe_table_pk": "CONTYPE = 'p'",
+            "describe_table_fk": "CONTYPE = 'f'",
+        }[qid],
+    )
+
+    with pytest.raises(NetezzaError) as exc:
+        describe_table(_profile(), database="DB", schema="S", table="T")
+
+    assert (
+        "COLUMN_NAME" in exc.value.context["detail"] or "DATA_TYPE" in exc.value.context["detail"]
+    )
+
+
+def test_describe_table_pk_bad_dict_raises(monkeypatch: pytest.MonkeyPatch) -> None:
+    buckets = {
+        "columns": [("ID", "INT", True, None, 1)],
+        "dist": [],
+        "pk": [{"CONSTRAINTNAME": "p", "ATTNAME": "ID"}],
+        "fk": [],
+    }
+    cursor = _RoutingCursor(buckets)
+    monkeypatch.setattr(tables_mod, "get_password", lambda _n: "pw")
+    monkeypatch.setattr(tables_mod, "open_connection", lambda *_a, **_k: _FakeConn(cursor))
+    monkeypatch.setattr(
+        tables_mod,
+        "resolve_query",
+        lambda qid, _p: {
+            "describe_table_columns": "_V_RELATION_COLUMN",
+            "describe_table_distribution": "_V_TABLE_DIST_MAP",
+            "describe_table_pk": "CONTYPE = 'p'",
+            "describe_table_fk": "CONTYPE = 'f'",
+        }[qid],
+    )
+
+    with pytest.raises(NetezzaError) as exc:
+        describe_table(_profile(), database="DB", schema="S", table="T")
+
+    assert "CONSEQ" in exc.value.context["detail"]
+
+
+def test_describe_table_fk_bad_row_missing_constraint_raises(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    buckets = {
+        "columns": [("ID", "INT", True, None, 1)],
+        "dist": [],
+        "pk": [],
+        "fk": [{"ATTNAME": "ID", "CONSEQ": 1}],
+    }
+    cursor = _RoutingCursor(buckets)
+    monkeypatch.setattr(tables_mod, "get_password", lambda _n: "pw")
+    monkeypatch.setattr(tables_mod, "open_connection", lambda *_a, **_k: _FakeConn(cursor))
+    monkeypatch.setattr(
+        tables_mod,
+        "resolve_query",
+        lambda qid, _p: {
+            "describe_table_columns": "_V_RELATION_COLUMN",
+            "describe_table_distribution": "_V_TABLE_DIST_MAP",
+            "describe_table_pk": "CONTYPE = 'p'",
+            "describe_table_fk": "CONTYPE = 'f'",
+        }[qid],
+    )
+
+    with pytest.raises(NetezzaError) as exc:
+        describe_table(_profile(), database="DB", schema="S", table="T")
+
+    assert "CONSTRAINTNAME" in exc.value.context["detail"]
+
+
+def test_describe_table_column_tuple_too_short_raises(monkeypatch: pytest.MonkeyPatch) -> None:
+    buckets = {
+        "columns": [("A", "B", 0)],
+        "dist": [],
+        "pk": [],
+        "fk": [],
+    }
+    cursor = _RoutingCursor(buckets)
+    monkeypatch.setattr(tables_mod, "get_password", lambda _n: "pw")
+    monkeypatch.setattr(tables_mod, "open_connection", lambda *_a, **_k: _FakeConn(cursor))
+    monkeypatch.setattr(
+        tables_mod,
+        "resolve_query",
+        lambda qid, _p: {
+            "describe_table_columns": "_V_RELATION_COLUMN",
+            "describe_table_distribution": "_V_TABLE_DIST_MAP",
+            "describe_table_pk": "CONTYPE = 'p'",
+            "describe_table_fk": "CONTYPE = 'f'",
+        }[qid],
+    )
+
+    with pytest.raises(NetezzaError) as exc:
+        describe_table(_profile(), database="DB", schema="S", table="T")
+
+    assert "column row" in exc.value.context["detail"].lower()
+
+
+def test_describe_table_not_null_zero_and_f_string(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Cover _is_not_null branches for 0 and 'f' string values."""
+    buckets = {
+        "columns": [
+            ("A", "INT", 0, None, 1),
+            ("B", "INT", "f", None, 2),
+        ],
+        "dist": [],
+        "pk": [],
+        "fk": [],
+    }
+    cursor = _RoutingCursor(buckets)
+    monkeypatch.setattr(tables_mod, "get_password", lambda _n: "pw")
+    monkeypatch.setattr(tables_mod, "open_connection", lambda *_a, **_k: _FakeConn(cursor))
+    monkeypatch.setattr(
+        tables_mod,
+        "resolve_query",
+        lambda qid, _p: {
+            "describe_table_columns": "_V_RELATION_COLUMN",
+            "describe_table_distribution": "_V_TABLE_DIST_MAP",
+            "describe_table_pk": "CONTYPE = 'p'",
+            "describe_table_fk": "CONTYPE = 'f'",
+        }[qid],
+    )
+
+    out = describe_table(_profile(), database="DB", schema="S", table="T")
+    assert out["columns"][0]["nullable"] is True
+    assert out["columns"][1]["nullable"] is True

--- a/tests/unit/test_tools_describe_table.py
+++ b/tests/unit/test_tools_describe_table.py
@@ -1,0 +1,83 @@
+"""Tests for ``nz_describe_table`` MCP tool."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from nz_mcp.errors import NetezzaError, ObjectNotFoundError
+from nz_mcp.tools.describe_table import DescribeTableInput, nz_describe_table
+
+
+def test_describe_table_input_accepts_wire_keys() -> None:
+    parsed = DescribeTableInput.model_validate(
+        {"database": "DEV", "schema": "PUBLIC", "table": "T"},
+    )
+    assert parsed.table_schema == "PUBLIC"
+    assert parsed.table == "T"
+
+
+def test_nz_describe_table_happy_path(monkeypatch: pytest.MonkeyPatch, two_profiles: Path) -> None:
+    payload: dict[str, object] = {
+        "name": "T",
+        "kind": "TABLE",
+        "columns": [
+            {"name": "ID", "type": "INTEGER", "nullable": False, "default": None},
+        ],
+        "distribution": {"type": "RANDOM", "columns": []},
+        "organized_on": [],
+        "primary_key": [],
+        "foreign_keys": [],
+    }
+
+    def _fake_describe(
+        _profile: object,
+        database: str,
+        schema: str,
+        table: str,
+    ) -> dict[str, object]:
+        assert database == "DEV"
+        assert schema == "PUBLIC"
+        assert table == "t"
+        return payload
+
+    monkeypatch.setattr("nz_mcp.tools.describe_table.describe_table", _fake_describe)
+
+    out = nz_describe_table(
+        DescribeTableInput(database="DEV", table_schema="PUBLIC", table="t"),
+        config_path=two_profiles,
+    )
+
+    assert out.name == "T"
+    assert out.columns[0].sql_type == "INTEGER"
+
+
+def test_nz_describe_table_propagates_not_found(
+    monkeypatch: pytest.MonkeyPatch, two_profiles: Path
+) -> None:
+    def _raise(*_a: object, **_k: object) -> dict[str, object]:
+        raise ObjectNotFoundError(detail="missing")
+
+    monkeypatch.setattr("nz_mcp.tools.describe_table.describe_table", _raise)
+
+    with pytest.raises(ObjectNotFoundError):
+        nz_describe_table(
+            DescribeTableInput(database="DEV", table_schema="PUBLIC", table="X"),
+            config_path=two_profiles,
+        )
+
+
+def test_nz_describe_table_propagates_netezza_error(
+    monkeypatch: pytest.MonkeyPatch, two_profiles: Path
+) -> None:
+    def _raise(*_a: object, **_k: object) -> dict[str, object]:
+        raise NetezzaError(operation="describe_table", detail="driver")
+
+    monkeypatch.setattr("nz_mcp.tools.describe_table.describe_table", _raise)
+
+    with pytest.raises(NetezzaError):
+        nz_describe_table(
+            DescribeTableInput(database="DEV", table_schema="PUBLIC", table="X"),
+            config_path=two_profiles,
+        )


### PR DESCRIPTION
## ¿Qué cambia?
Añade `nz_describe_table` que combina en una sola respuesta columnas, distribución HASH/RANDOM, PK y FK leyendo las cuatro consultas de catálogo en **una conexión**, con `ObjectNotFoundError` cuando la tabla no existe (cero columnas).

## Issue relacionado
Closes #43

## Acción según AGENTS.md
- **Ruta (keywords)**: nueva tool, catálogo, describe, metadata
- **Docs**: `docs/architecture/tools-contract.md` §6, `AGENTS.md`

## Archivos esperados (según el issue)
- `src/nz_mcp/catalog/tables.py` (extendido con `describe_table`)
- `src/nz_mcp/tools/describe_table.py`
- `src/nz_mcp/tools/__init__.py`
- `tests/unit/test_catalog_describe_table.py`
- `tests/unit/test_tools_describe_table.py`
- `tests/integration/test_real_describe_table.py` (opcional)
- `tests/contract/test_mcp_tool_schemas.py`
- `CHANGELOG.md`
- `src/nz_mcp/server.py` (`model_dump(..., by_alias=True)` para serializar `type` en columnas/distribución)

## Auditoría pre-merge — 7 dimensiones

### 1. Contrato y compatibilidad
- [x] Comportamiento acorde a `tools-contract.md` §6 (`organized_on` vacío, `kind` TABLE).
- [x] `CHANGELOG.md` bilingüe en Added.

### 2. Seguridad
- [x] SQL parametrizado; errores con `sanitize(..., known_secrets={password})`.
- [x] Except defensivo catalog con `# noqa: BLE001, RUF100`.

### 3. Mantenibilidad y diseño
- [x] Una sola conexión para las 4 queries.

### 4. Tests
- [x] Unit catálogo (routing SQL, agregación, RANDOM, FK cross-db, no existe, error driver).
- [x] Unit tool + contrato `EXPECTED_V010A0`.

### 5. Tipado y estilo
- [x] `ruff` y `mypy --strict` locales verdes.

### 6. Documentación
- [x] CHANGELOG bilingüe.

### 7. Idioma y forma
- [x] Commit y título en español, conventional; código y comentarios en inglés.

## Validación humana requerida
- [ ] Sí — explicar por qué:
- [x] No

## Notas para el auditor
- `ForeignKeyReferences` usa `ref_schema` / `ref_table` con `alias` para evitar sombrear `BaseModel.schema`.
