### PR TITLE
feat(tools): añade nz_table_sample, nz_table_stats y nz_get_table_ddl

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ Cada entrada se documenta en **español** y **english**.
 - EN: driver error messages in `open_connection`, `list_databases`, and `probe-catalog` are passed through `sanitize()` with `known_secrets` so passwords are not leaked in MCP-exposed `detail` fields.
 
 ### Added
+- ES: tools `nz_table_sample`, `nz_table_stats` y `nz_get_table_ddl` — muestra de filas (`execute_select`), estadísticas de almacenamiento/datasets humanos IEC, y DDL `CREATE TABLE` reconstruido desde catálogo.
+- EN: `nz_table_sample`, `nz_table_stats`, and `nz_get_table_ddl` tools — row sampling via `execute_select`, storage/IEC-formatted stats, and catalog-reconstructed `CREATE TABLE` DDL.
+- ES: módulos `catalog/formatters.py` (`format_bytes_iec`) y `catalog/ddl_builder.py` (`build_create_table_ddl`).
+- EN: `catalog/formatters.py` (`format_bytes_iec`) and `catalog/ddl_builder.py` (`build_create_table_ddl`) modules.
 - ES: tools `nz_query_select` y `nz_explain` — ejecución de `SELECT` validado con `sql_guard`, `LIMIT` automático/streaming, y planes `EXPLAIN`/`EXPLAIN VERBOSE` sin ejecutar la query.
 - EN: `nz_query_select` and `nz_explain` tools — `sql_guard`-validated `SELECT` execution with automatic `LIMIT`/streaming, and `EXPLAIN`/`EXPLAIN VERBOSE` plans without executing the query.
 - ES: tool `nz_describe_table` para metadata de tabla (columnas, distribución, PK, FK) vía catálogo `_v_*`.

--- a/docs/architecture/tools-contract.md
+++ b/docs/architecture/tools-contract.md
@@ -137,22 +137,22 @@ Lista **solo tablas** (no vistas, no procedimientos). Para vistas usar `nz_list_
 
 #### 7. `nz_table_sample`
 
-Devuelve una muestra pequeña (10 filas) para entender el shape.
+Devuelve una muestra pequeña (10 filas) para entender el shape. El `database` del input **debe coincidir** con el de la conexión del perfil activo (muestreo vía `SELECT` en la sesión).
 
 | Input | Tipo | Descripción |
 |---|---|---|
-| `database` | string (required) | |
+| `database` | string (required) | Debe ser el de la conexión del perfil. |
 | `schema` | string (required) | |
 | `table` | string (required) | |
 | `rows` | int (default 10, cap 50) | |
 
-**Output**: mismo formato que `nz_query_select`.
+**Output**: mismo formato que `nz_query_select` (incl. `columns`, `rows`, `row_count`, `truncated`, `duration_ms`, `hint`).
 
 ---
 
 #### 8. `nz_table_stats`
 
-Estadísticas agregadas desde `_v_statistic` y `_v_table_storage_stat`.
+Estadísticas agregadas desde `_V_TABLE` y `_V_TABLE_STORAGE_STAT` (reltuples, bytes almacenados, skew, creación).
 
 | Input | Tipo | Descripción |
 |---|---|---|
@@ -164,9 +164,12 @@ Estadísticas agregadas desde `_v_statistic` y `_v_table_storage_stat`.
 ```json
 {
   "row_count": 1200000,
-  "size_bytes_uncompressed": 2400000000,
-  "size_bytes_compressed": 600000000,
-  "last_statistic_update": "2026-04-10T12:00:00Z"
+  "size_bytes_used": 600000000,
+  "size_used_human": "572.2 MiB",
+  "size_bytes_allocated": 800000000,
+  "size_allocated_human": "762.9 MiB",
+  "skew": 1.02,
+  "table_created": "2025-01-10T00:00:00+00:00"
 }
 ```
 
@@ -174,23 +177,25 @@ Estadísticas agregadas desde `_v_statistic` y `_v_table_storage_stat`.
 
 #### 9. `nz_get_table_ddl`
 
-Devuelve el DDL `CREATE TABLE` reconstruido (columnas, tipos, distribución, organized-on, constraints).
+Devuelve el DDL `CREATE TABLE` reconstruido (columnas, tipos, distribución, constraints opcionales). **No** usa `SHOW TABLE` en el servidor: se arman claves y metadatos desde catálogos.
 
 | Input | Tipo | Descripción |
 |---|---|---|
 | `database` | string (required) | |
 | `schema` | string (required) | |
 | `table` | string (required) | |
-| `include_constraints` | bool (default: true) | Incluir PK/FK/CHECK. |
+| `include_constraints` | bool (default: true) | Incluir PK/FK. |
 
 **Output**:
 ```json
 {
-  "ddl": "CREATE TABLE PUBLIC.CUSTOMERS (\n  ID INTEGER NOT NULL,\n  ...\n) DISTRIBUTE ON (ID);"
+  "ddl": "CREATE TABLE PUBLIC.CUSTOMERS (\n  ID INTEGER NOT NULL,\n  ...\n)\nDISTRIBUTE ON HASH (ID);",
+  "reconstructed": true,
+  "notes": ["DDL reconstruido desde catálogo …"]
 }
 ```
 
-Implementación: `SHOW TABLE schema.table;` si está disponible, o reconstruir desde `_v_relation_column` + `_v_table_dist_map` + `_v_table_constraint`.
+Implementación: reconstruir desde `_v_relation_column` + `_v_table_dist_map` + `_v_relation_keydata` (misma base que `nz_describe_table`).
 
 ---
 

--- a/src/nz_mcp/catalog/ddl_builder.py
+++ b/src/nz_mcp/catalog/ddl_builder.py
@@ -1,0 +1,55 @@
+"""Rebuild CREATE TABLE DDL text from structured catalog metadata."""
+
+from __future__ import annotations
+
+from typing import Any
+
+
+def build_create_table_ddl(
+    *,
+    fq_name: str,
+    columns: list[dict[str, Any]],
+    distribution: dict[str, Any],
+    primary_key: list[str],
+    foreign_keys: list[dict[str, Any]],
+    include_constraints: bool,
+) -> str:
+    """Return a ``CREATE TABLE`` statement for Netezza-style DDL (uppercase identifiers)."""
+    lines: list[str] = []
+    for col in columns:
+        nm = str(col["name"])
+        dt = str(col["type"])
+        nullable = bool(col.get("nullable", True))
+        default = col.get("default")
+        segment = f"  {nm} {dt}"
+        if not nullable:
+            segment += " NOT NULL"
+        if default not in (None, ""):
+            segment += f" DEFAULT {default}"
+        lines.append(segment)
+
+    if include_constraints and primary_key:
+        cols = ", ".join(primary_key)
+        lines.append(f"  PRIMARY KEY ({cols})")
+
+    if include_constraints:
+        for fk in foreign_keys:
+            name = str(fk["name"])
+            local_cols = ", ".join(str(x) for x in fk["columns"])
+            ref = fk["references"]
+            rs = str(ref["schema"])
+            rt = str(ref["table"])
+            rcols = ", ".join(str(x) for x in ref["columns"])
+            lines.append(
+                f"  CONSTRAINT {name} FOREIGN KEY ({local_cols}) REFERENCES {rs}.{rt} ({rcols})",
+            )
+
+    inner = ",\n".join(lines)
+    dist_type = str(distribution.get("type", "RANDOM")).upper()
+    dist_cols = distribution.get("columns") or []
+    if dist_type == "HASH" and isinstance(dist_cols, list) and len(dist_cols) > 0:
+        dist_clause = f"DISTRIBUTE ON HASH ({', '.join(str(c) for c in dist_cols)})"
+    else:
+        dist_clause = "DISTRIBUTE ON RANDOM"
+
+    return f"CREATE TABLE {fq_name} (\n{inner}\n)\n{dist_clause};"

--- a/src/nz_mcp/catalog/formatters.py
+++ b/src/nz_mcp/catalog/formatters.py
@@ -1,0 +1,22 @@
+"""Human-readable formatting helpers for catalog metadata."""
+
+from __future__ import annotations
+
+_UNITS: tuple[str, ...] = ("B", "KiB", "MiB", "GiB", "TiB", "PiB")
+_IEC_BASE: int = 1024
+
+
+def format_bytes_iec(n: int) -> str:
+    """Format ``n`` bytes using IEC binary units (KiB = 1024 B), one fractional digit."""
+    if n < 0:
+        raise ValueError("byte count must be non-negative")
+    if n == 0:
+        return "0 B"
+    idx = 0
+    size = float(n)
+    while size >= _IEC_BASE and idx < len(_UNITS) - 1:
+        size /= _IEC_BASE
+        idx += 1
+    if idx == 0:
+        return f"{int(size)} B"
+    return f"{size:.1f} {_UNITS[idx]}"

--- a/src/nz_mcp/catalog/identifier.py
+++ b/src/nz_mcp/catalog/identifier.py
@@ -21,6 +21,16 @@ def validate_database_identifier(name: str) -> str:
     return normalized
 
 
+def validate_catalog_identifier(name: str) -> str:
+    """Validate schema, table, or other single-part SQL identifiers (uppercase unquoted)."""
+    normalized = name.strip().upper()
+    if not _DB_IDENTIFIER_PATTERN.fullmatch(normalized):
+        raise InvalidInputError(
+            detail=f"Invalid catalog identifier: {name!r}",
+        )
+    return normalized
+
+
 def render_cross_db(sql: str, database: str) -> str:
     """Replace ``<BD>..`` markers with a validated database identifier."""
     validated = validate_database_identifier(database)

--- a/src/nz_mcp/catalog/tables.py
+++ b/src/nz_mcp/catalog/tables.py
@@ -7,12 +7,21 @@ from contextlib import closing
 from typing import Any, Final, Protocol, cast
 
 from nz_mcp.auth import get_password
-from nz_mcp.catalog.identifier import render_cross_db
+from nz_mcp.catalog.ddl_builder import build_create_table_ddl
+from nz_mcp.catalog.execute import execute_select, inject_limit
+from nz_mcp.catalog.formatters import format_bytes_iec
+from nz_mcp.catalog.identifier import (
+    render_cross_db,
+    validate_catalog_identifier,
+    validate_database_identifier,
+)
 from nz_mcp.catalog.resolver import resolve_query
 from nz_mcp.config import Profile
 from nz_mcp.connection import open_connection
-from nz_mcp.errors import NetezzaError, ObjectNotFoundError
+from nz_mcp.errors import InvalidInputError, NetezzaError, ObjectNotFoundError
 from nz_mcp.logging_utils import sanitize
+from nz_mcp.sql_guard import StatementKind
+from nz_mcp.sql_guard import validate as guard_validate
 
 _TABLE_ROW_MIN_ITEMS: Final[int] = 2
 _TABLE_KIND: Final[str] = "TABLE"
@@ -23,6 +32,7 @@ _FK_PK_MIN: Final[int] = 4
 _FK_SCHEMA_MIN: Final[int] = 5
 _FK_REL_MIN: Final[int] = 6
 _FK_ATT_MIN: Final[int] = 7
+_STATS_ROW_MIN: Final[int] = 5
 
 
 class _DescribeCursorLike(Protocol):
@@ -363,3 +373,171 @@ def _fk_ref_column(row: Any) -> str:
     if isinstance(row, tuple) and len(row) >= _FK_ATT_MIN:
         return str(row[6])
     raise NetezzaError(operation="describe_table", detail="Unexpected FK row shape.")
+
+
+def _ensure_profile_database(profile: Profile, database: str) -> None:
+    """Direct ``SELECT`` runs in the session database; reject cross-database mismatch."""
+    db_arg = validate_database_identifier(database)
+    db_sess = validate_database_identifier(profile.database)
+    if db_arg != db_sess:
+        raise InvalidInputError(
+            detail=(
+                "The database argument must match the active profile database "
+                f"({db_sess}) when sampling table rows."
+            ),
+        )
+
+
+def get_table_sample(
+    profile: Profile,
+    database: str,
+    schema: str,
+    table: str,
+    *,
+    rows: int,
+    timeout_s: int,
+) -> dict[str, Any]:
+    """Run a bounded ``SELECT *`` for sampling; SQL is validated via ``sql_guard``."""
+    _ensure_profile_database(profile, database)
+    schema_u = validate_catalog_identifier(schema)
+    table_u = validate_catalog_identifier(table)
+    sql = f"SELECT * FROM {schema_u}.{table_u}"  # noqa: S608 identifiers validated above
+    parsed = guard_validate(sql, mode="read")
+    if parsed.kind is not StatementKind.SELECT:
+        raise NetezzaError(
+            operation="get_table_sample",
+            detail=f"Unexpected statement kind after validation: {parsed.kind}",
+        )
+    limited = inject_limit(parsed.raw, rows)
+    return execute_select(
+        profile,
+        limited,
+        max_rows=rows,
+        timeout_s=timeout_s,
+    )
+
+
+def get_table_stats(
+    profile: Profile,
+    database: str,
+    schema: str,
+    table: str,
+) -> dict[str, Any]:
+    """Return row estimate, storage bytes, skew, and creation time from catalog views."""
+    params: tuple[str, str] = (
+        validate_catalog_identifier(schema),
+        validate_catalog_identifier(table),
+    )
+    password = get_password(profile.name)
+    sql = render_cross_db(resolve_query("table_stats", profile), database=database)
+
+    connection = cast(_DescribeConnectionLike, open_connection(profile, password))
+    try:
+        with closing(connection.cursor()) as cursor:
+            cursor.execute(sql, params)
+            fetched = cursor.fetchall()
+    except Exception as exc:  # noqa: BLE001, RUF100
+        raise NetezzaError(
+            operation="get_table_stats",
+            database=database,
+            detail=sanitize(str(exc), known_secrets={password}),
+        ) from exc
+    finally:
+        connection.close()
+
+    if not fetched:
+        raise ObjectNotFoundError(
+            detail=(
+                "No statistics row returned — table may not exist or may not be visible "
+                f"(database={database!r}, schema={schema!r}, table={table!r})."
+            ),
+        )
+
+    payload = _parse_table_stats_row(fetched[0])
+    used = int(payload["size_bytes_used"])
+    allocated = int(payload["size_bytes_allocated"])
+    return {
+        "row_count": int(payload["row_count"]),
+        "size_bytes_used": used,
+        "size_used_human": format_bytes_iec(used),
+        "size_bytes_allocated": allocated,
+        "size_allocated_human": format_bytes_iec(allocated),
+        "skew": payload["skew"],
+        "table_created": payload["table_created"],
+    }
+
+
+def _parse_table_stats_row(row: Any) -> dict[str, Any]:
+    """Normalize driver row shapes for ``table_stats`` query aliases."""
+    if isinstance(row, dict):
+
+        def pick(*candidates: str) -> Any:
+            keys = {str(k).upper(): v for k, v in row.items()}
+            for c in candidates:
+                if c.upper() in keys:
+                    return keys[c.upper()]
+            return None
+
+        rc = pick("ROW_COUNT")
+        used = pick("SIZE_BYTES_USED")
+        alloc = pick("SIZE_BYTES_ALLOCATED")
+        skew = pick("SKEW")
+        created = pick("TABLE_CREATED")
+    elif isinstance(row, tuple) and len(row) >= _STATS_ROW_MIN:
+        rc, used, alloc, skew, created = (
+            row[0],
+            row[1],
+            row[2],
+            row[3],
+            row[4],
+        )
+    else:
+        raise NetezzaError(
+            operation="get_table_stats",
+            detail="Unexpected row shape from table_stats catalog query.",
+        )
+
+    skew_out: float | None = None if skew is None else float(skew)
+
+    created_out: str | None
+    if created is None:
+        created_out = None
+    else:
+        iso = getattr(created, "isoformat", None)
+        created_out = iso() if callable(iso) else str(created)
+
+    return {
+        "row_count": 0 if rc is None else int(rc),
+        "size_bytes_used": 0 if used is None else int(used),
+        "size_bytes_allocated": 0 if alloc is None else int(alloc),
+        "skew": skew_out,
+        "table_created": created_out,
+    }
+
+
+def get_table_ddl(
+    profile: Profile,
+    database: str,
+    schema: str,
+    table: str,
+    *,
+    include_constraints: bool,
+) -> dict[str, Any]:
+    """Rebuild CREATE TABLE DDL from catalog metadata (no ``SHOW TABLE``)."""
+    schema_u = validate_catalog_identifier(schema)
+    table_u = validate_catalog_identifier(table)
+    meta = describe_table(profile, database, schema_u, table_u)
+    fq = f"{schema_u}.{table_u}"
+    ddl = build_create_table_ddl(
+        fq_name=fq,
+        columns=list(meta["columns"]),
+        distribution=dict(meta["distribution"]),
+        primary_key=list(meta["primary_key"]),
+        foreign_keys=list(meta["foreign_keys"]),
+        include_constraints=include_constraints,
+    )
+    return {
+        "ddl": ddl,
+        "reconstructed": True,
+        "notes": [],
+    }

--- a/src/nz_mcp/i18n.py
+++ b/src/nz_mcp/i18n.py
@@ -99,6 +99,10 @@ MESSAGES: Final[dict[str, Message]] = {
         "es": "Se alcanzó el límite de tiempo ({timeout_s}s). El resultado puede estar incompleto.",
         "en": "Execution time limit ({timeout_s}s) was reached. The result may be incomplete.",
     },
+    "NOTE.DDL_RECONSTRUCTED": {
+        "es": "DDL reconstruido desde catálogo (SHOW TABLE no disponible en este servidor).",
+        "en": "DDL reconstructed from catalogs (SHOW TABLE not available on this server).",
+    },
     # nz-mcp doctor (CLI diagnostics — no secrets)
     "DOCTOR.HEADER": {
         "es": "Diagnóstico local (nz-mcp doctor)",

--- a/src/nz_mcp/tools/query.py
+++ b/src/nz_mcp/tools/query.py
@@ -58,7 +58,8 @@ def _resolved_timeout(profile_timeout: int, arg: int | None) -> int:
     return min(base, TIMEOUT_S_CAP)
 
 
-def _hint_from_execute(payload: dict[str, object]) -> str | None:
+def hint_from_execute_payload(payload: dict[str, object]) -> str | None:
+    """Build a localized hint string from an ``execute_select`` result payload."""
     key = payload.get("hint_key")
     if not isinstance(key, str):
         return None
@@ -104,7 +105,7 @@ def nz_query_select(
         max_rows=max_rows,
         timeout_s=timeout_s,
     )
-    hint = _hint_from_execute(raw)
+    hint = hint_from_execute_payload(raw)
     columns = [
         ColumnMeta.model_validate({"name": c["name"], "type": c["type"]}) for c in raw["columns"]
     ]

--- a/src/nz_mcp/tools/tables.py
+++ b/src/nz_mcp/tools/tables.py
@@ -7,9 +7,13 @@ from typing import Literal
 
 from pydantic import BaseModel, ConfigDict, Field
 
-from nz_mcp.catalog.tables import list_tables
+from nz_mcp.catalog.tables import get_table_ddl, get_table_sample, get_table_stats, list_tables
 from nz_mcp.config import get_active_profile
+from nz_mcp.i18n import resolve_locale, t
+from nz_mcp.tools.query import ColumnMeta, QuerySelectOutput, hint_from_execute_payload
 from nz_mcp.tools.registry import tool
+
+_TABLE_SAMPLE_ROWS_CAP: int = 50
 
 
 class ListTablesInput(BaseModel):
@@ -32,6 +36,59 @@ class TableItem(BaseModel):
 class ListTablesOutput(BaseModel):
     model_config = ConfigDict(extra="forbid")
     tables: list[TableItem]
+
+
+class TableSampleInput(BaseModel):
+    model_config = ConfigDict(extra="forbid", populate_by_name=True)
+    database: str = Field(min_length=1, max_length=128)
+    table_schema: str = Field(
+        alias="schema",
+        min_length=1,
+        max_length=128,
+    )
+    table: str = Field(min_length=1, max_length=128)
+    rows: int = Field(default=10, ge=1, le=_TABLE_SAMPLE_ROWS_CAP)
+
+
+class TableStatsInput(BaseModel):
+    model_config = ConfigDict(extra="forbid", populate_by_name=True)
+    database: str = Field(min_length=1, max_length=128)
+    table_schema: str = Field(
+        alias="schema",
+        min_length=1,
+        max_length=128,
+    )
+    table: str = Field(min_length=1, max_length=128)
+
+
+class TableStatsOutput(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+    row_count: int
+    size_bytes_used: int
+    size_used_human: str
+    size_bytes_allocated: int
+    size_allocated_human: str
+    skew: float | None
+    table_created: str | None
+
+
+class GetTableDdlInput(BaseModel):
+    model_config = ConfigDict(extra="forbid", populate_by_name=True)
+    database: str = Field(min_length=1, max_length=128)
+    table_schema: str = Field(
+        alias="schema",
+        min_length=1,
+        max_length=128,
+    )
+    table: str = Field(min_length=1, max_length=128)
+    include_constraints: bool = True
+
+
+class GetTableDdlOutput(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+    ddl: str
+    reconstructed: bool = True
+    notes: list[str]
 
 
 @tool(
@@ -60,4 +117,103 @@ def nz_list_tables(
     )
     return ListTablesOutput(
         tables=[TableItem(name=row["name"], kind="TABLE") for row in rows],
+    )
+
+
+@tool(
+    name="nz_table_sample",
+    description=(
+        "Return a small row sample from a base table (SELECT with a row cap). "
+        "Use after nz_list_tables / nz_describe_table. "
+        "Database must match the active profile database."
+    ),
+    mode="read",
+    input_model=TableSampleInput,
+    output_model=QuerySelectOutput,
+    annotations={"readOnlyHint": True, "idempotentHint": True, "openWorldHint": False},
+)
+def nz_table_sample(
+    params: TableSampleInput,
+    *,
+    config_path: Path | None = None,
+) -> QuerySelectOutput:
+    profile = get_active_profile(path=config_path)
+    raw = get_table_sample(
+        profile,
+        database=params.database,
+        schema=params.table_schema,
+        table=params.table,
+        rows=params.rows,
+        timeout_s=profile.timeout_s_default,
+    )
+    hint = hint_from_execute_payload(raw)
+    columns = [
+        ColumnMeta.model_validate({"name": c["name"], "type": c["type"]}) for c in raw["columns"]
+    ]
+    return QuerySelectOutput(
+        columns=columns,
+        rows=raw["rows"],
+        row_count=int(raw["row_count"]),
+        truncated=bool(raw["truncated"]),
+        duration_ms=int(raw["duration_ms"]),
+        hint=hint,
+    )
+
+
+@tool(
+    name="nz_table_stats",
+    description=(
+        "Return estimated row count and on-disk storage metrics for a base table "
+        "from catalog statistics. Use for capacity planning."
+    ),
+    mode="read",
+    input_model=TableStatsInput,
+    output_model=TableStatsOutput,
+    annotations={"readOnlyHint": True, "idempotentHint": True, "openWorldHint": False},
+)
+def nz_table_stats(
+    params: TableStatsInput,
+    *,
+    config_path: Path | None = None,
+) -> TableStatsOutput:
+    profile = get_active_profile(path=config_path)
+    payload = get_table_stats(
+        profile,
+        database=params.database,
+        schema=params.table_schema,
+        table=params.table,
+    )
+    return TableStatsOutput.model_validate(payload)
+
+
+@tool(
+    name="nz_get_table_ddl",
+    description=(
+        "Return a reconstructed CREATE TABLE DDL string from system catalogs "
+        "(SHOW TABLE is not used). Optionally omit constraints."
+    ),
+    mode="read",
+    input_model=GetTableDdlInput,
+    output_model=GetTableDdlOutput,
+    annotations={"readOnlyHint": True, "idempotentHint": True, "openWorldHint": False},
+)
+def nz_get_table_ddl(
+    params: GetTableDdlInput,
+    *,
+    config_path: Path | None = None,
+) -> GetTableDdlOutput:
+    profile = get_active_profile(path=config_path)
+    payload = get_table_ddl(
+        profile,
+        database=params.database,
+        schema=params.table_schema,
+        table=params.table,
+        include_constraints=params.include_constraints,
+    )
+    loc = resolve_locale()
+    note = t("NOTE.DDL_RECONSTRUCTED", loc)
+    return GetTableDdlOutput(
+        ddl=payload["ddl"],
+        reconstructed=bool(payload["reconstructed"]),
+        notes=[note],
     )

--- a/tests/contract/test_mcp_tool_schemas.py
+++ b/tests/contract/test_mcp_tool_schemas.py
@@ -17,6 +17,7 @@ EXPECTED_V010A0: set[str] = {
     "nz_current_profile",
     "nz_describe_table",
     "nz_explain",
+    "nz_get_table_ddl",
     "nz_get_view_ddl",
     "nz_list_databases",
     "nz_list_schemas",
@@ -24,6 +25,8 @@ EXPECTED_V010A0: set[str] = {
     "nz_list_views",
     "nz_query_select",
     "nz_switch_profile",
+    "nz_table_sample",
+    "nz_table_stats",
 }
 
 

--- a/tests/unit/test_catalog_ddl_builder.py
+++ b/tests/unit/test_catalog_ddl_builder.py
@@ -1,0 +1,73 @@
+"""Tests for CREATE TABLE DDL reconstruction."""
+
+from __future__ import annotations
+
+from nz_mcp.catalog.ddl_builder import build_create_table_ddl
+
+
+def test_build_ddl_hash_distribution_and_pk() -> None:
+    ddl = build_create_table_ddl(
+        fq_name="PUBLIC.T",
+        columns=[
+            {"name": "ID", "type": "INT", "nullable": False, "default": None},
+            {"name": "N", "type": "VARCHAR(10)", "nullable": True, "default": None},
+        ],
+        distribution={"type": "HASH", "columns": ["ID"]},
+        primary_key=["ID"],
+        foreign_keys=[],
+        include_constraints=True,
+    )
+    assert "CREATE TABLE PUBLIC.T" in ddl
+    assert "DISTRIBUTE ON HASH (ID)" in ddl
+    assert "PRIMARY KEY (ID)" in ddl
+    assert "NOT NULL" in ddl
+
+
+def test_build_ddl_random_no_constraints() -> None:
+    ddl = build_create_table_ddl(
+        fq_name="S.T",
+        columns=[{"name": "X", "type": "INT", "nullable": True, "default": None}],
+        distribution={"type": "RANDOM", "columns": []},
+        primary_key=[],
+        foreign_keys=[],
+        include_constraints=False,
+    )
+    assert "DISTRIBUTE ON RANDOM" in ddl
+    assert "PRIMARY KEY" not in ddl
+
+
+def test_build_ddl_column_default_rendered() -> None:
+    ddl = build_create_table_ddl(
+        fq_name="S.T",
+        columns=[
+            {"name": "N", "type": "INT", "nullable": True, "default": "42"},
+        ],
+        distribution={"type": "RANDOM", "columns": []},
+        primary_key=[],
+        foreign_keys=[],
+        include_constraints=False,
+    )
+    assert "DEFAULT 42" in ddl
+
+
+def test_build_ddl_foreign_key() -> None:
+    ddl = build_create_table_ddl(
+        fq_name="S.CHILD",
+        columns=[{"name": "ID", "type": "INT", "nullable": False, "default": None}],
+        distribution={"type": "HASH", "columns": ["ID"]},
+        primary_key=[],
+        foreign_keys=[
+            {
+                "name": "FK1",
+                "columns": ["ID"],
+                "references": {
+                    "database": None,
+                    "schema": "S",
+                    "table": "PARENT",
+                    "columns": ["ID"],
+                },
+            },
+        ],
+        include_constraints=True,
+    )
+    assert "FOREIGN KEY (ID) REFERENCES S.PARENT (ID)" in ddl

--- a/tests/unit/test_catalog_formatters.py
+++ b/tests/unit/test_catalog_formatters.py
@@ -1,0 +1,27 @@
+"""Tests for IEC byte formatting."""
+
+from __future__ import annotations
+
+import pytest
+
+from nz_mcp.catalog.formatters import format_bytes_iec
+
+
+@pytest.mark.parametrize(
+    ("n", "expected"),
+    [
+        (0, "0 B"),
+        (1, "1 B"),
+        (1023, "1023 B"),
+        (1024, "1.0 KiB"),
+        (1048576, "1.0 MiB"),
+        (1536, "1.5 KiB"),
+    ],
+)
+def test_format_bytes_iec(n: int, expected: str) -> None:
+    assert format_bytes_iec(n) == expected
+
+
+def test_format_bytes_iec_negative_raises() -> None:
+    with pytest.raises(ValueError):
+        format_bytes_iec(-1)

--- a/tests/unit/test_catalog_identifier.py
+++ b/tests/unit/test_catalog_identifier.py
@@ -8,7 +8,11 @@ import pytest
 from hypothesis import given
 from hypothesis import strategies as st
 
-from nz_mcp.catalog.identifier import render_cross_db, validate_database_identifier
+from nz_mcp.catalog.identifier import (
+    render_cross_db,
+    validate_catalog_identifier,
+    validate_database_identifier,
+)
 from nz_mcp.errors import InvalidInputError
 
 _VALIDATED_PATTERN = re.compile(r"^[A-Z][A-Z0-9_]{0,127}$")
@@ -47,6 +51,16 @@ def test_validate_database_identifier_rejects_adversarial_values(name: str) -> N
     with pytest.raises(InvalidInputError) as exc:
         validate_database_identifier(name)
     assert exc.value.code == "INVALID_DATABASE_NAME"
+
+
+def test_validate_catalog_identifier_rejects_injection() -> None:
+    with pytest.raises(InvalidInputError) as exc:
+        validate_catalog_identifier("X; DROP TABLE")
+    assert exc.value.code == "INVALID_INPUT"
+
+
+def test_validate_catalog_identifier_normalizes_case() -> None:
+    assert validate_catalog_identifier("mytab") == "MYTAB"
 
 
 def test_render_cross_db_replaces_all_markers() -> None:

--- a/tests/unit/test_catalog_tables_introspection.py
+++ b/tests/unit/test_catalog_tables_introspection.py
@@ -1,0 +1,150 @@
+"""Tests for table sampling, statistics, and DDL reconstruction."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+import pytest
+
+from nz_mcp.catalog import tables as tables_mod
+from nz_mcp.catalog.tables import (
+    _parse_table_stats_row,
+    get_table_ddl,
+    get_table_sample,
+    get_table_stats,
+)
+from nz_mcp.config import Profile
+from nz_mcp.errors import InvalidInputError, ObjectNotFoundError
+
+
+def _profile_dev() -> Profile:
+    return Profile(
+        name="dev",
+        host="h",
+        port=5480,
+        database="DEV",
+        user="u",
+        mode="read",
+    )
+
+
+def test_get_table_sample_rejects_database_mismatch() -> None:
+    with pytest.raises(InvalidInputError):
+        get_table_sample(
+            _profile_dev(),
+            database="OTHER",
+            schema="PUBLIC",
+            table="T",
+            rows=5,
+            timeout_s=30,
+        )
+
+
+def test_get_table_sample_runs_guarded_select(monkeypatch: pytest.MonkeyPatch) -> None:
+    captured: dict[str, object] = {}
+
+    def _exec(
+        _profile: object,
+        sql: str,
+        *,
+        max_rows: int,
+        timeout_s: int,
+    ) -> dict[str, object]:
+        captured["sql"] = sql
+        captured["max_rows"] = max_rows
+        return {
+            "columns": [{"name": "n", "type": "int"}],
+            "rows": [[1]],
+            "row_count": 1,
+            "truncated": False,
+            "duration_ms": 1,
+            "hint_key": None,
+            "hint_fmt": {},
+        }
+
+    monkeypatch.setattr(tables_mod, "execute_select", _exec)
+
+    out = get_table_sample(
+        _profile_dev(),
+        database="DEV",
+        schema="PUBLIC",
+        table="T",
+        rows=3,
+        timeout_s=30,
+    )
+    assert out["row_count"] == 1
+    assert "PUBLIC.T" in str(captured["sql"]).upper()
+    assert captured["max_rows"] == 3
+
+
+def test_parse_table_stats_tuple() -> None:
+    p = _parse_table_stats_row((10, 1024, 2048, 2.5, None))
+    assert p["row_count"] == 10
+    assert p["size_bytes_used"] == 1024
+    assert p["size_bytes_allocated"] == 2048
+    assert p["skew"] == 2.5
+    assert p["table_created"] is None
+
+
+def test_parse_table_stats_dict_datetime() -> None:
+    dt = datetime(2026, 4, 1, 12, 0, 0, tzinfo=UTC)
+    p = _parse_table_stats_row(
+        {
+            "ROW_COUNT": 1,
+            "SIZE_BYTES_USED": 100,
+            "SIZE_BYTES_ALLOCATED": 200,
+            "SKEW": None,
+            "TABLE_CREATED": dt,
+        },
+    )
+    assert "2026-04-01" in (p["table_created"] or "")
+
+
+def test_get_table_stats_missing_row(monkeypatch: pytest.MonkeyPatch) -> None:
+    class _Cur:
+        def execute(self, _sql: str, _params: tuple[str, str]) -> None:
+            return None
+
+        def fetchall(self) -> list[object]:
+            return []
+
+        def close(self) -> None:
+            return None
+
+    class _Conn:
+        def cursor(self) -> _Cur:
+            return _Cur()
+
+        def close(self) -> None:
+            return None
+
+    monkeypatch.setattr(tables_mod, "get_password", lambda _n: "pw")
+    monkeypatch.setattr(tables_mod, "open_connection", lambda _p, _pw: _Conn())
+
+    with pytest.raises(ObjectNotFoundError):
+        get_table_stats(_profile_dev(), database="DEV", schema="PUBLIC", table="Z")
+
+
+def test_get_table_ddl_builds_from_describe(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(
+        tables_mod,
+        "describe_table",
+        lambda *_a, **_kw: {
+            "name": "T",
+            "kind": "TABLE",
+            "columns": [{"name": "ID", "type": "INT", "nullable": False, "default": None}],
+            "distribution": {"type": "HASH", "columns": ["ID"]},
+            "primary_key": ["ID"],
+            "foreign_keys": [],
+        },
+    )
+
+    out = get_table_ddl(
+        _profile_dev(),
+        database="DEV",
+        schema="PUBLIC",
+        table="T",
+        include_constraints=True,
+    )
+    assert "CREATE TABLE PUBLIC.T" in out["ddl"]
+    assert out["reconstructed"] is True

--- a/tests/unit/test_tools_table_introspection.py
+++ b/tests/unit/test_tools_table_introspection.py
@@ -1,0 +1,106 @@
+"""Tests for nz_table_sample, nz_table_stats, nz_get_table_ddl."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from nz_mcp.tools.tables import (
+    GetTableDdlInput,
+    TableSampleInput,
+    TableStatsInput,
+    nz_get_table_ddl,
+    nz_table_sample,
+    nz_table_stats,
+)
+
+
+def test_nz_table_sample_wire_schema_key(two_profiles: Path) -> None:
+    parsed = TableSampleInput.model_validate(
+        {"database": "DEV", "schema": "PUBLIC", "table": "T", "rows": 5},
+    )
+    assert parsed.table_schema == "PUBLIC"
+
+
+def test_nz_table_sample_happy_path(monkeypatch: pytest.MonkeyPatch, two_profiles: Path) -> None:
+
+    def _sample(
+        _profile: object,
+        database: str,
+        schema: str,
+        table: str,
+        *,
+        rows: int,
+        timeout_s: int,
+    ) -> dict[str, object]:
+        assert database == "DEV"
+        assert schema == "PUBLIC"
+        assert table == "T"
+        assert rows == 10
+        return {
+            "columns": [{"name": "c", "type": "INT"}],
+            "rows": [[42]],
+            "row_count": 1,
+            "truncated": False,
+            "duration_ms": 5,
+            "hint_key": None,
+            "hint_fmt": {},
+        }
+
+    monkeypatch.setattr("nz_mcp.tools.tables.get_table_sample", _sample)
+
+    out = nz_table_sample(
+        TableSampleInput(database="DEV", table_schema="PUBLIC", table="T"),
+        config_path=two_profiles,
+    )
+    assert out.rows == [[42]]
+    assert out.row_count == 1
+
+
+def test_nz_table_stats_happy_path(monkeypatch: pytest.MonkeyPatch, two_profiles: Path) -> None:
+
+    def _stats(_p: object, **_kw: object) -> dict[str, object]:
+        return {
+            "row_count": 100,
+            "size_bytes_used": 1024,
+            "size_used_human": "1.0 KiB",
+            "size_bytes_allocated": 2048,
+            "size_allocated_human": "2.0 KiB",
+            "skew": 1.2,
+            "table_created": "2026-01-01",
+        }
+
+    monkeypatch.setattr("nz_mcp.tools.tables.get_table_stats", _stats)
+
+    out = nz_table_stats(
+        TableStatsInput(database="DEV", table_schema="PUBLIC", table="T"),
+        config_path=two_profiles,
+    )
+    assert out.row_count == 100
+    assert out.skew == 1.2
+
+
+def test_nz_get_table_ddl_notes(monkeypatch: pytest.MonkeyPatch, two_profiles: Path) -> None:
+
+    def _get_ddl(
+        _profile: object,
+        database: str,
+        schema: str,
+        table: str,
+        *,
+        include_constraints: bool,
+    ) -> dict[str, object]:
+        assert database == "DEV" and schema == "PUBLIC" and table == "T"
+        assert include_constraints is True
+        return {"ddl": "CREATE TABLE X (\n);\n", "reconstructed": True}
+
+    monkeypatch.setattr("nz_mcp.tools.tables.get_table_ddl", _get_ddl)
+
+    out = nz_get_table_ddl(
+        GetTableDdlInput(database="DEV", table_schema="PUBLIC", table="T"),
+        config_path=two_profiles,
+    )
+    assert out.reconstructed is True
+    assert len(out.notes) == 1
+    assert "SHOW TABLE" in out.notes[0]


### PR DESCRIPTION
## ¿Qué cambia?

Tres tools de introspección de tablas: muestreo de filas (vía `sql_guard` + `execute_select` + `inject_limit`), estadísticas de almacenamiento con bytes e IEC humano, y DDL `CREATE TABLE` reconstruido desde catálogo. Nuevos módulos `format_bytes_iec` y `build_create_table_ddl`. `database` en muestreo debe coincidir con el de la conexión del perfil.

## Issue relacionado

Closes #46

## Acción según AGENTS.md

- **Ruta (keywords)**: nueva tool, catálogo, `sql_guard`, `execute_select`, `tools-contract`, CHANGELOG.
- **Docs leídos**:
  - `docs/architecture/tools-contract.md`
  - `docs/standards/testing.md`
  - `docs/standards/pr-audit.md`
- **Rol asumido**: Backend Developer + QA Engineer.

## Archivos esperados (según el issue)

| Esperado | Estado |
|---|---|
| `catalog/formatters.py` | `format_bytes_iec` |
| `catalog/ddl_builder.py` | `build_create_table_ddl` |
| `catalog/tables.py` | `get_table_sample`, `get_table_stats`, `get_table_ddl` |
| Herramientas MCP | `nz_table_sample`, `nz_table_stats`, `nz_get_table_ddl` en `tools/tables.py` |
| Contrato / CHANGELOG / EXPECTED | Actualizados |

## Auditoría pre-merge — 7 dimensiones

### 1. Contrato y compatibilidad

- [x] Si toca tools: `tools-contract.md` actualizado en este PR.
- [x] Cambio observable: `CHANGELOG.md` con entradas bilingües en `Unreleased`.
- [x] Sin breaking change inesperado.

### 2. Seguridad

- [x] Todo SQL ejecutable en muestreo pasa por `sql_guard.validate()`.
- [x] Identificadores `database`/`schema`/`table` validados antes de interpolar en `SELECT`.
- [x] Sin credenciales en código, logs o tests.

### 3. Mantenibilidad y diseño

- [x] Alcance acotado al paquete de tablas (#46).
- [x] Sin nuevas dependencias ni ADR.
- [x] Una intención por PR.

### 4. Tests

- [x] Tests unitarios para formatters, ddl_builder, catalog, tools y contrato.
- [x] `pytest -m "not integration"` verde local.
- [x] Cobertura global ≥ 85 % (`formatters.py` y `ddl_builder.py` al 100 %).

### 5. Tipado y estilo

- [x] `ruff check .` / `ruff format --check .`
- [x] `mypy` sin errores.

### 6. Documentación

- [x] Mensaje `NOTE.DDL_RECONSTRUCTED` en ES y EN.

### 7. Idioma y forma

- [x] Mensaje de commit conforme al regex CI (`feat`).
- [x] Código y comentarios en inglés.

## Validación humana requerida

- [ ] Sí — explicar por qué:
- [x] No

## Notas para el auditor

- `hint_from_execute_payload` extraído a función pública en `query.py` para reutilizar en `nz_table_sample`.
- `nz_table_sample`: mismatch `database` vs perfil → `InvalidInputError`.
