### PR TITLE
feat(tools): paquete write nz_insert, nz_update y nz_delete

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ Cada entrada se documenta en **español** y **english**.
 - EN: driver error messages in `open_connection`, `list_databases`, and `probe-catalog` are passed through `sanitize()` with `known_secrets` so passwords are not leaked in MCP-exposed `detail` fields.
 
 ### Added
+- ES: paquete write — `nz_insert`, `nz_update`, `nz_delete` con SQL parametrizado, `sql_guard` en modo `write`, dry-run con `COUNT` y `confirm` para mutaciones reales.
+- EN: write package — `nz_insert`, `nz_update`, `nz_delete` with parameterized SQL, `sql_guard` in `write` mode, dry-run via `COUNT` and `confirm` for real mutations.
 - ES: paquete de procedures — `nz_list_procedures`, `nz_describe_procedure`, `nz_get_procedure_ddl`, `nz_get_procedure_section` (parser NZPLSQL por marcadores, rangos de líneas acotados).
 - EN: procedures package — `nz_list_procedures`, `nz_describe_procedure`, `nz_get_procedure_ddl`, `nz_get_procedure_section` (marker-based NZPLSQL parser, capped line ranges).
 - ES: tools `nz_table_sample`, `nz_table_stats` y `nz_get_table_ddl` — muestra de filas (`execute_select`), estadísticas de almacenamiento/datasets humanos IEC, y DDL `CREATE TABLE` reconstruido desde catálogo.

--- a/docs/architecture/tools-contract.md
+++ b/docs/architecture/tools-contract.md
@@ -362,7 +362,7 @@ Implementación: parser ligero NZPLSQL en `catalog/procedures.py` (basado en mar
 
 **Output**: `{ "inserted": N, "duration_ms": T }`
 
-Implementación: `INSERT INTO ... VALUES (...)` parametrizado. **Prohibido** construir SQL por concatenación de strings.
+Implementación: `INSERT INTO ... VALUES (...)` parametrizado. **Prohibido** construir SQL por concatenación de strings de valores (identificadores validados con el validador de catálogo).
 
 ---
 
@@ -378,7 +378,9 @@ Implementación: `INSERT INTO ... VALUES (...)` parametrizado. **Prohibido** con
 | `dry_run` | bool (default true) | Ejecuta `SELECT COUNT(*) WHERE ...` primero y pide `confirm: true` para aplicar. |
 | `confirm` | bool (default false) | Requerido si `dry_run: false`. |
 
-**Output**: `{ "updated": N, "duration_ms": T, "dry_run": bool }`
+**Output** (dry-run `true`): `{ "updated": 0, "would_update": N, "dry_run": true, "confirm_required": true, "duration_ms": T }`
+
+**Output** (ejecución real): `{ "updated": N, "duration_ms": T, "dry_run": false }`
 
 **Regla de seguridad**: `sql_guard` rechaza `UPDATE` sin `WHERE`.
 
@@ -388,7 +390,11 @@ Implementación: `INSERT INTO ... VALUES (...)` parametrizado. **Prohibido** con
 
 Mismo patrón que `nz_update` con `where` obligatorio, `dry_run` default `true`.
 
-**Output**: `{ "deleted": N, "duration_ms": T, "dry_run": bool }`
+**Output** (dry-run `true`): `{ "deleted": 0, "would_delete": N, "dry_run": true, "confirm_required": true, "duration_ms": T }`
+
+**Output** (ejecución real): `{ "deleted": N, "duration_ms": T, "dry_run": false }`
+
+Si `dry_run=false` sin `confirm=true` → código estable `CONFIRM_REQUIRED`.
 
 ---
 
@@ -539,7 +545,7 @@ Todas las tools devuelven errores con estructura estable:
 ```
 
 Códigos estables (contrato):
-`GUARD_REJECTED`, `PERMISSION_DENIED`, `PROFILE_NOT_FOUND`, `CONNECTION_FAILED`, `QUERY_TIMEOUT`, `RESULT_TOO_LARGE`, `INVALID_INPUT`, `NETEZZA_ERROR`, `INTERNAL_ERROR`, `OBJECT_NOT_FOUND`, `SECTION_NOT_FOUND`, `PROCEDURE_ALREADY_EXISTS`, `OVERLOAD_AMBIGUOUS`, `CLONE_VALIDATION_FAILED`.
+`GUARD_REJECTED`, `PERMISSION_DENIED`, `PROFILE_NOT_FOUND`, `CONNECTION_FAILED`, `QUERY_TIMEOUT`, `RESULT_TOO_LARGE`, `INVALID_INPUT`, `CONFIRM_REQUIRED`, `NETEZZA_ERROR`, `INTERNAL_ERROR`, `OBJECT_NOT_FOUND`, `SECTION_NOT_FOUND`, `PROCEDURE_ALREADY_EXISTS`, `OVERLOAD_AMBIGUOUS`, `CLONE_VALIDATION_FAILED`.
 
 ### Descripciones de tool (lo que ve la IA)
 

--- a/src/nz_mcp/catalog/write.py
+++ b/src/nz_mcp/catalog/write.py
@@ -1,0 +1,330 @@
+"""Parameterized DML helpers (INSERT / UPDATE / DELETE) with ``sql_guard`` validation."""
+
+from __future__ import annotations
+
+import time
+from contextlib import closing
+from typing import Any, Final, Protocol, cast
+
+from nz_mcp.auth import get_password
+from nz_mcp.catalog.identifier import validate_catalog_identifier, validate_database_identifier
+from nz_mcp.config import Profile
+from nz_mcp.connection import open_connection
+from nz_mcp.errors import InvalidInputError, NetezzaError
+from nz_mcp.logging_utils import sanitize
+from nz_mcp.sql_guard import StatementKind
+from nz_mcp.sql_guard import validate as guard_validate
+
+_MAX_INSERT_ROWS: Final[int] = 500
+
+
+class _CursorLike(Protocol):
+    def execute(self, sql: str, params: tuple[Any, ...] | None = None) -> None: ...
+    def fetchone(self) -> Any: ...
+    @property
+    def rowcount(self) -> int: ...
+    def close(self) -> None: ...
+
+
+class _ConnectionLike(Protocol):
+    def cursor(self) -> _CursorLike: ...
+    def close(self) -> None: ...
+
+
+def _ensure_session_database(profile: Profile, database: str) -> None:
+    db_arg = validate_database_identifier(database)
+    db_sess = validate_database_identifier(profile.database)
+    if db_arg != db_sess:
+        raise InvalidInputError(
+            detail=(
+                "The database argument must match the active profile database "
+                f"({db_sess}) for write operations."
+            ),
+        )
+
+
+def _qualified_table(schema: str, table: str) -> str:
+    return f"{validate_catalog_identifier(schema)}.{validate_catalog_identifier(table)}"
+
+
+def _validate_column_name(name: str) -> str:
+    return validate_catalog_identifier(name)
+
+
+def _is_duplicate_row_error(exc: BaseException) -> bool:
+    msg = str(exc).lower()
+    return "duplicate" in msg or "unique" in msg or "23505" in msg
+
+
+def execute_insert(  # noqa: PLR0912, PLR0915
+    profile: Profile,
+    database: str,
+    schema: str,
+    table: str,
+    rows: list[dict[str, Any]],
+    *,
+    on_conflict: str,
+) -> dict[str, Any]:
+    """Run ``INSERT`` with ``?`` placeholders; ``on_conflict`` is ``error`` or ``skip``."""
+    _ensure_session_database(profile, database)
+    if not rows:
+        raise InvalidInputError(detail="rows must contain at least one object for nz_insert.")
+    if len(rows) > _MAX_INSERT_ROWS:
+        raise InvalidInputError(
+            detail=f"Too many rows in one call (max {_MAX_INSERT_ROWS}).",
+        )
+    if on_conflict not in ("error", "skip"):
+        raise InvalidInputError(detail="on_conflict must be 'error' or 'skip'.")
+
+    first_keys = sorted(rows[0].keys())
+    for i, row in enumerate(rows):
+        keys = sorted(row.keys())
+        if keys != first_keys:
+            raise InvalidInputError(
+                detail=f"Row {i} keys do not match the first row column set.",
+            )
+
+    cols = [_validate_column_name(k) for k in first_keys]
+    qual = _qualified_table(schema, table)
+    placeholders = "(" + ", ".join(["?"] * len(cols)) + ")"
+    values_clause = ", ".join([placeholders] * len(rows))
+    sql = f"INSERT INTO {qual} ({', '.join(cols)}) VALUES {values_clause}"  # noqa: S608
+
+    flat_params: list[Any] = []
+    for row in rows:
+        for c in first_keys:
+            flat_params.append(row[c])
+    params_tuple = tuple(flat_params)
+
+    parsed = guard_validate(sql, mode="write")
+    if parsed.kind is not StatementKind.INSERT:
+        raise NetezzaError(
+            operation="execute_insert",
+            detail=f"Unexpected statement kind after validation: {parsed.kind}",
+        )
+
+    password = get_password(profile.name)
+    connection = cast(_ConnectionLike, open_connection(profile, password))
+    start = time.monotonic()
+    try:
+        with closing(connection.cursor()) as cursor:
+            if on_conflict == "error":
+                cursor.execute(parsed.raw, params_tuple)
+                inserted = len(rows)
+            else:
+                inserted = 0
+                single_sql = f"INSERT INTO {qual} ({', '.join(cols)}) VALUES {placeholders}"  # noqa: S608
+                single_parsed = guard_validate(single_sql, mode="write")
+                for row in rows:
+                    p = tuple(row[k] for k in first_keys)
+                    try:
+                        cursor.execute(single_parsed.raw, p)
+                        inserted += 1
+                    except Exception as exc:  # noqa: BLE001, RUF100
+                        if _is_duplicate_row_error(exc):
+                            continue
+                        raise NetezzaError(
+                            operation="execute_insert",
+                            database=database,
+                            detail=sanitize(str(exc), known_secrets={password}),
+                        ) from exc
+    except NetezzaError:
+        raise
+    except Exception as exc:  # noqa: BLE001, RUF100
+        raise NetezzaError(
+            operation="execute_insert",
+            database=database,
+            detail=sanitize(str(exc), known_secrets={password}),
+        ) from exc
+    finally:
+        connection.close()
+
+    duration_ms = int((time.monotonic() - start) * 1000)
+    return {"inserted": inserted, "duration_ms": duration_ms}
+
+
+def execute_update(
+    profile: Profile,
+    database: str,
+    schema: str,
+    table: str,
+    set_cols: dict[str, Any],
+    where: str,
+    *,
+    dry_run: bool,
+    confirm: bool,
+) -> dict[str, Any]:
+    """Run ``UPDATE`` with validation, optional dry-run ``COUNT`` first."""
+    _ensure_session_database(profile, database)
+    if not set_cols:
+        raise InvalidInputError(detail="set must contain at least one column.")
+    where_clause = where.strip()
+    if not where_clause:
+        raise InvalidInputError(detail="where must be a non-empty predicate.")
+
+    qual = _qualified_table(schema, table)
+    set_parts = [f"{_validate_column_name(k)} = ?" for k in sorted(set_cols.keys())]
+    set_sql = ", ".join(set_parts)
+    set_params = tuple(set_cols[k] for k in sorted(set_cols.keys()))
+
+    update_sql = f"UPDATE {qual} SET {set_sql} WHERE {where_clause}"  # noqa: S608
+    password = get_password(profile.name)
+
+    if dry_run:
+        count_sql = f"SELECT COUNT(*) AS C FROM {qual} WHERE {where_clause}"  # noqa: S608
+        count_parsed = guard_validate(count_sql, mode="read")
+        if count_parsed.kind is not StatementKind.SELECT:
+            raise NetezzaError(
+                operation="execute_update",
+                detail=f"Unexpected statement kind for dry-run count: {count_parsed.kind}",
+            )
+        start = time.monotonic()
+        n = _run_scalar_count(profile, password, count_parsed.raw, ())
+        duration_ms = int((time.monotonic() - start) * 1000)
+        return {
+            "updated": 0,
+            "would_update": n,
+            "dry_run": True,
+            "confirm_required": True,
+            "duration_ms": duration_ms,
+        }
+
+    if not confirm:
+        raise InvalidInputError(
+            code="CONFIRM_REQUIRED",
+            detail="confirm=true is required when dry_run=false for nz_update.",
+        )
+
+    parsed = guard_validate(update_sql, mode="write")
+    if parsed.kind is not StatementKind.UPDATE:
+        raise NetezzaError(
+            operation="execute_update",
+            detail=f"Unexpected statement kind after validation: {parsed.kind}",
+        )
+
+    start = time.monotonic()
+    connection = cast(_ConnectionLike, open_connection(profile, password))
+    try:
+        with closing(connection.cursor()) as cursor:
+            cursor.execute(parsed.raw, set_params)
+            affected = cursor.rowcount if cursor.rowcount is not None else 0
+    except Exception as exc:  # noqa: BLE001, RUF100
+        raise NetezzaError(
+            operation="execute_update",
+            database=database,
+            detail=sanitize(str(exc), known_secrets={password}),
+        ) from exc
+    finally:
+        connection.close()
+
+    duration_ms = int((time.monotonic() - start) * 1000)
+    return {
+        "updated": int(affected),
+        "dry_run": False,
+        "duration_ms": duration_ms,
+    }
+
+
+def execute_delete(
+    profile: Profile,
+    database: str,
+    schema: str,
+    table: str,
+    where: str,
+    *,
+    dry_run: bool,
+    confirm: bool,
+) -> dict[str, Any]:
+    """Run ``DELETE`` with validation, optional dry-run ``COUNT`` first."""
+    _ensure_session_database(profile, database)
+    where_clause = where.strip()
+    if not where_clause:
+        raise InvalidInputError(detail="where must be a non-empty predicate.")
+
+    qual = _qualified_table(schema, table)
+    delete_sql = f"DELETE FROM {qual} WHERE {where_clause}"  # noqa: S608
+    password = get_password(profile.name)
+
+    if dry_run:
+        count_sql = f"SELECT COUNT(*) AS C FROM {qual} WHERE {where_clause}"  # noqa: S608
+        count_parsed = guard_validate(count_sql, mode="read")
+        if count_parsed.kind is not StatementKind.SELECT:
+            raise NetezzaError(
+                operation="execute_delete",
+                detail=f"Unexpected statement kind for dry-run count: {count_parsed.kind}",
+            )
+        start = time.monotonic()
+        n = _run_scalar_count(profile, password, count_parsed.raw, ())
+        duration_ms = int((time.monotonic() - start) * 1000)
+        return {
+            "deleted": 0,
+            "would_delete": n,
+            "dry_run": True,
+            "confirm_required": True,
+            "duration_ms": duration_ms,
+        }
+
+    if not confirm:
+        raise InvalidInputError(
+            code="CONFIRM_REQUIRED",
+            detail="confirm=true is required when dry_run=false for nz_delete.",
+        )
+
+    parsed = guard_validate(delete_sql, mode="write")
+    if parsed.kind is not StatementKind.DELETE:
+        raise NetezzaError(
+            operation="execute_delete",
+            detail=f"Unexpected statement kind after validation: {parsed.kind}",
+        )
+
+    start = time.monotonic()
+    connection = cast(_ConnectionLike, open_connection(profile, password))
+    try:
+        with closing(connection.cursor()) as cursor:
+            cursor.execute(parsed.raw, ())
+            affected = cursor.rowcount if cursor.rowcount is not None else 0
+    except Exception as exc:  # noqa: BLE001, RUF100
+        raise NetezzaError(
+            operation="execute_delete",
+            database=database,
+            detail=sanitize(str(exc), known_secrets={password}),
+        ) from exc
+    finally:
+        connection.close()
+
+    duration_ms = int((time.monotonic() - start) * 1000)
+    return {
+        "deleted": int(affected),
+        "dry_run": False,
+        "duration_ms": duration_ms,
+    }
+
+
+def _run_scalar_count(
+    profile: Profile,
+    password: str,
+    sql: str,
+    params: tuple[Any, ...],
+) -> int:
+    connection = cast(_ConnectionLike, open_connection(profile, password))
+    try:
+        with closing(connection.cursor()) as cursor:
+            cursor.execute(sql, params)
+            row = cursor.fetchone()
+    except Exception as exc:  # noqa: BLE001, RUF100
+        raise NetezzaError(
+            operation="execute_update",
+            database=profile.database,
+            detail=sanitize(str(exc), known_secrets={password}),
+        ) from exc
+    finally:
+        connection.close()
+
+    if row is None:
+        return 0
+    if isinstance(row, dict):
+        v = next(iter(row.values()))
+        return int(v)
+    if isinstance(row, (tuple, list)) and len(row) >= 1:
+        return int(row[0])
+    return int(row)

--- a/src/nz_mcp/i18n.py
+++ b/src/nz_mcp/i18n.py
@@ -90,6 +90,10 @@ MESSAGES: Final[dict[str, Message]] = {
         "es": "Hay varias sobrecargas para el procedimiento '{procedure}'; indica proceduresignature.",
         "en": "Multiple overloads exist for procedure '{procedure}'; specify proceduresignature.",
     },
+    "CONFIRM_REQUIRED": {
+        "es": "Se requiere confirm=true para ejecutar la mutación con dry_run=false.",
+        "en": "confirm=true is required to run the mutation with dry_run=false.",
+    },
     # Hints
     "HINT.RESULT_TRUNCATED": {
         "es": "Resultado truncado en {n} filas. Añade WHERE o LIMIT para refinar.",

--- a/src/nz_mcp/server.py
+++ b/src/nz_mcp/server.py
@@ -115,6 +115,7 @@ def _i18n_key_for(code: str) -> str | None:
         "WRONG_STATEMENT_FOR_TOOL": "GUARD_REJECTED.WRONG_STATEMENT_FOR_TOOL",
         "SECTION_NOT_FOUND": "SECTION_NOT_FOUND",
         "OVERLOAD_AMBIGUOUS": "OVERLOAD_AMBIGUOUS",
+        "CONFIRM_REQUIRED": "CONFIRM_REQUIRED",
     }
     return mapping.get(code)
 

--- a/src/nz_mcp/tools/__init__.py
+++ b/src/nz_mcp/tools/__init__.py
@@ -14,6 +14,7 @@ from nz_mcp.tools import (
     session,  # noqa: F401  (registers session tools)
     tables,  # noqa: F401  (registers table tools)
     views,  # noqa: F401  (registers view tools)
+    write,  # noqa: F401  (registers nz_insert, nz_update, nz_delete)
 )
 from nz_mcp.tools.registry import TOOLS, ToolSpec
 

--- a/src/nz_mcp/tools/write.py
+++ b/src/nz_mcp/tools/write.py
@@ -1,0 +1,210 @@
+"""Write tools (INSERT / UPDATE / DELETE) with ``sql_guard`` and dry-run defaults."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any, Literal
+
+from pydantic import BaseModel, ConfigDict, Field, field_validator
+
+from nz_mcp.catalog.write import execute_delete, execute_insert, execute_update
+from nz_mcp.config import get_active_profile
+from nz_mcp.tools.registry import tool
+
+
+class InsertInput(BaseModel):
+    model_config = ConfigDict(extra="forbid", populate_by_name=True)
+    database: str = Field(min_length=1, max_length=128)
+    table_schema: str = Field(alias="schema", min_length=1, max_length=128)
+    table: str = Field(min_length=1, max_length=128)
+    rows: list[dict[str, Any]]
+    on_conflict: Literal["error", "skip"] = "error"
+
+
+class InsertOutput(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+    inserted: int
+    duration_ms: int
+
+
+class UpdateInput(BaseModel):
+    model_config = ConfigDict(extra="forbid", populate_by_name=True)
+    database: str = Field(min_length=1, max_length=128)
+    table_schema: str = Field(alias="schema", min_length=1, max_length=128)
+    table: str = Field(min_length=1, max_length=128)
+    set: dict[str, Any] = Field(min_length=1)
+    where: str = Field(min_length=1, max_length=8192)
+    dry_run: bool = True
+    confirm: bool = False
+
+    @field_validator("where")
+    @classmethod
+    def strip_where(cls, v: str) -> str:
+        s = v.strip()
+        if not s:
+            msg = "where must be a non-empty predicate"
+            raise ValueError(msg)
+        return s
+
+
+class UpdateOutput(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+    updated: int
+    duration_ms: int
+    dry_run: bool
+    would_update: int | None = None
+    confirm_required: bool | None = None
+
+
+class DeleteInput(BaseModel):
+    model_config = ConfigDict(extra="forbid", populate_by_name=True)
+    database: str = Field(min_length=1, max_length=128)
+    table_schema: str = Field(alias="schema", min_length=1, max_length=128)
+    table: str = Field(min_length=1, max_length=128)
+    where: str = Field(min_length=1, max_length=8192)
+    dry_run: bool = True
+    confirm: bool = False
+
+    @field_validator("where")
+    @classmethod
+    def strip_where(cls, v: str) -> str:
+        s = v.strip()
+        if not s:
+            msg = "where must be a non-empty predicate"
+            raise ValueError(msg)
+        return s
+
+
+class DeleteOutput(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+    deleted: int
+    duration_ms: int
+    dry_run: bool
+    would_delete: int | None = None
+    confirm_required: bool | None = None
+
+
+@tool(
+    name="nz_insert",
+    description=(
+        "Insert rows into a base table using parameterized INSERT. "
+        "Requires profile mode write or admin. Database must match the active profile database."
+    ),
+    mode="write",
+    input_model=InsertInput,
+    output_model=InsertOutput,
+    annotations={
+        "readOnlyHint": False,
+        "destructiveHint": False,
+        "idempotentHint": False,
+        "openWorldHint": False,
+    },
+)
+def nz_insert(
+    params: InsertInput,
+    *,
+    config_path: Path | None = None,
+) -> InsertOutput:
+    profile = get_active_profile(path=config_path)
+    raw = execute_insert(
+        profile,
+        database=params.database,
+        schema=params.table_schema,
+        table=params.table,
+        rows=list(params.rows),
+        on_conflict=params.on_conflict,
+    )
+    return InsertOutput(inserted=int(raw["inserted"]), duration_ms=int(raw["duration_ms"]))
+
+
+@tool(
+    name="nz_update",
+    description=(
+        "Update rows in a base table; WHERE is mandatory. Default dry_run=true runs COUNT only; "
+        "set dry_run=false and confirm=true to apply."
+    ),
+    mode="write",
+    input_model=UpdateInput,
+    output_model=UpdateOutput,
+    annotations={
+        "readOnlyHint": False,
+        "destructiveHint": True,
+        "idempotentHint": False,
+        "openWorldHint": False,
+    },
+)
+def nz_update(
+    params: UpdateInput,
+    *,
+    config_path: Path | None = None,
+) -> UpdateOutput:
+    profile = get_active_profile(path=config_path)
+    raw = execute_update(
+        profile,
+        database=params.database,
+        schema=params.table_schema,
+        table=params.table,
+        set_cols=dict(params.set),
+        where=params.where,
+        dry_run=params.dry_run,
+        confirm=params.confirm,
+    )
+    if raw.get("dry_run"):
+        return UpdateOutput(
+            updated=0,
+            duration_ms=int(raw["duration_ms"]),
+            dry_run=True,
+            would_update=int(raw["would_update"]),
+            confirm_required=bool(raw["confirm_required"]),
+        )
+    return UpdateOutput(
+        updated=int(raw["updated"]),
+        duration_ms=int(raw["duration_ms"]),
+        dry_run=False,
+    )
+
+
+@tool(
+    name="nz_delete",
+    description=(
+        "Delete rows from a base table; WHERE is mandatory. Default dry_run=true counts matches; "
+        "set dry_run=false and confirm=true to execute DELETE."
+    ),
+    mode="write",
+    input_model=DeleteInput,
+    output_model=DeleteOutput,
+    annotations={
+        "readOnlyHint": False,
+        "destructiveHint": True,
+        "idempotentHint": False,
+        "openWorldHint": False,
+    },
+)
+def nz_delete(
+    params: DeleteInput,
+    *,
+    config_path: Path | None = None,
+) -> DeleteOutput:
+    profile = get_active_profile(path=config_path)
+    raw = execute_delete(
+        profile,
+        database=params.database,
+        schema=params.table_schema,
+        table=params.table,
+        where=params.where,
+        dry_run=params.dry_run,
+        confirm=params.confirm,
+    )
+    if raw.get("dry_run"):
+        return DeleteOutput(
+            deleted=0,
+            duration_ms=int(raw["duration_ms"]),
+            dry_run=True,
+            would_delete=int(raw["would_delete"]),
+            confirm_required=bool(raw["confirm_required"]),
+        )
+    return DeleteOutput(
+        deleted=int(raw["deleted"]),
+        duration_ms=int(raw["duration_ms"]),
+        dry_run=False,
+    )

--- a/tests/contract/test_mcp_tool_schemas.py
+++ b/tests/contract/test_mcp_tool_schemas.py
@@ -15,6 +15,7 @@ from nz_mcp.tools.registry import TOOLS
 
 EXPECTED_V010A0: set[str] = {
     "nz_current_profile",
+    "nz_delete",
     "nz_describe_procedure",
     "nz_describe_table",
     "nz_explain",
@@ -22,6 +23,7 @@ EXPECTED_V010A0: set[str] = {
     "nz_get_procedure_section",
     "nz_get_table_ddl",
     "nz_get_view_ddl",
+    "nz_insert",
     "nz_list_databases",
     "nz_list_procedures",
     "nz_list_schemas",
@@ -31,6 +33,7 @@ EXPECTED_V010A0: set[str] = {
     "nz_switch_profile",
     "nz_table_sample",
     "nz_table_stats",
+    "nz_update",
 }
 
 

--- a/tests/unit/test_catalog_write.py
+++ b/tests/unit/test_catalog_write.py
@@ -1,0 +1,214 @@
+"""Unit tests for catalog write helpers (mocked DB)."""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import MagicMock
+
+import pytest
+
+from nz_mcp.catalog.write import _run_scalar_count, execute_delete, execute_insert, execute_update
+from nz_mcp.config import Profile
+from nz_mcp.errors import GuardRejectedError, InvalidInputError
+from nz_mcp.sql_guard import validate as guard_validate
+
+_PROFILE = Profile(
+    name="dev",
+    host="h",
+    port=5480,
+    database="DEV",
+    user="u",
+    mode="write",
+)
+
+
+def _mock_conn(cursor: MagicMock) -> MagicMock:
+    """``closing(connection.cursor())`` expects the cursor object directly."""
+    conn = MagicMock()
+    conn.cursor.return_value = cursor
+    return conn
+
+
+def test_execute_insert_empty_rows() -> None:
+    with pytest.raises(InvalidInputError):
+        execute_insert(_PROFILE, "DEV", "PUBLIC", "T", [], on_conflict="error")
+
+
+def test_execute_insert_too_many_rows() -> None:
+    rows = [{"A": 1} for _ in range(501)]
+    with pytest.raises(InvalidInputError):
+        execute_insert(_PROFILE, "DEV", "PUBLIC", "T", rows, on_conflict="error")
+
+
+def test_execute_insert_on_conflict_invalid() -> None:
+    with pytest.raises(InvalidInputError):
+        execute_insert(_PROFILE, "DEV", "PUBLIC", "T", [{"A": 1}], on_conflict="bogus")
+
+
+def test_execute_insert_row_key_mismatch() -> None:
+    with pytest.raises(InvalidInputError):
+        execute_insert(
+            _PROFILE,
+            "DEV",
+            "PUBLIC",
+            "T",
+            [{"A": 1}, {"A": 1, "B": 2}],
+            on_conflict="error",
+        )
+
+
+def test_execute_insert_batch_error_path(monkeypatch: pytest.MonkeyPatch) -> None:
+    cursor = MagicMock()
+    conn = _mock_conn(cursor)
+    monkeypatch.setattr("nz_mcp.catalog.write.get_password", lambda _n: "pw")
+    monkeypatch.setattr("nz_mcp.catalog.write.open_connection", lambda *_a, **_k: conn)
+    rows = [{"A": 1, "B": 2}]
+    out = execute_insert(_PROFILE, "DEV", "PUBLIC", "TAB", rows, on_conflict="error")
+    assert out["inserted"] == 1
+    cursor.execute.assert_called_once()
+    assert "INSERT INTO PUBLIC.TAB" in cursor.execute.call_args[0][0]
+
+
+def test_execute_update_dry_run_count(monkeypatch: pytest.MonkeyPatch) -> None:
+    cursor = MagicMock()
+    cursor.fetchone.return_value = (5,)
+    conn = _mock_conn(cursor)
+    monkeypatch.setattr("nz_mcp.catalog.write.get_password", lambda _n: "pw")
+    monkeypatch.setattr("nz_mcp.catalog.write.open_connection", lambda *_a, **_k: conn)
+    out = execute_update(
+        _PROFILE,
+        "DEV",
+        "PUBLIC",
+        "TAB",
+        {"X": 1},
+        "ID = 1",
+        dry_run=True,
+        confirm=False,
+    )
+    assert out["dry_run"] is True
+    assert out["would_update"] == 5
+    assert "COUNT" in cursor.execute.call_args[0][0]
+
+
+def test_execute_update_confirm_required(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr("nz_mcp.catalog.write.get_password", lambda _n: "pw")
+    with pytest.raises(InvalidInputError) as ei:
+        execute_update(
+            _PROFILE,
+            "DEV",
+            "PUBLIC",
+            "TAB",
+            {"X": 1},
+            "ID = 1",
+            dry_run=False,
+            confirm=False,
+        )
+    assert ei.value.code == "CONFIRM_REQUIRED"
+
+
+def test_execute_delete_dry_run(monkeypatch: pytest.MonkeyPatch) -> None:
+    cursor = MagicMock()
+    cursor.fetchone.return_value = (3,)
+    conn = _mock_conn(cursor)
+    monkeypatch.setattr("nz_mcp.catalog.write.get_password", lambda _n: "pw")
+    monkeypatch.setattr("nz_mcp.catalog.write.open_connection", lambda *_a, **_k: conn)
+    out = execute_delete(
+        _PROFILE,
+        "DEV",
+        "PUBLIC",
+        "TAB",
+        "ID = 1",
+        dry_run=True,
+        confirm=False,
+    )
+    assert out["would_delete"] == 3
+
+
+def test_database_mismatch() -> None:
+    with pytest.raises(InvalidInputError):
+        execute_insert(
+            _PROFILE,
+            "OTHER",
+            "PUBLIC",
+            "T",
+            [{"A": 1}],
+            on_conflict="error",
+        )
+
+
+def test_guard_rejects_update_without_where() -> None:
+    with pytest.raises(GuardRejectedError) as ge:
+        guard_validate("UPDATE PUBLIC.T SET X=1", mode="write")
+    assert ge.value.code == "UPDATE_REQUIRES_WHERE"
+
+
+def test_guard_rejects_delete_without_where() -> None:
+    with pytest.raises(GuardRejectedError) as ge:
+        guard_validate("DELETE FROM PUBLIC.T", mode="write")
+    assert ge.value.code == "DELETE_REQUIRES_WHERE"
+
+
+def test_execute_update_real_execute(monkeypatch: pytest.MonkeyPatch) -> None:
+    cursor = MagicMock()
+    cursor.rowcount = 7
+    conn = _mock_conn(cursor)
+    monkeypatch.setattr("nz_mcp.catalog.write.get_password", lambda _n: "pw")
+    monkeypatch.setattr("nz_mcp.catalog.write.open_connection", lambda *_a, **_k: conn)
+    out = execute_update(
+        _PROFILE,
+        "DEV",
+        "PUBLIC",
+        "TAB",
+        {"X": 1},
+        "ID = 1",
+        dry_run=False,
+        confirm=True,
+    )
+    assert out["dry_run"] is False
+    assert out["updated"] == 7
+
+
+def test_execute_delete_real_execute(monkeypatch: pytest.MonkeyPatch) -> None:
+    cursor = MagicMock()
+    cursor.rowcount = 2
+    conn = _mock_conn(cursor)
+    monkeypatch.setattr("nz_mcp.catalog.write.get_password", lambda _n: "pw")
+    monkeypatch.setattr("nz_mcp.catalog.write.open_connection", lambda *_a, **_k: conn)
+    out = execute_delete(
+        _PROFILE,
+        "DEV",
+        "PUBLIC",
+        "TAB",
+        "ID = 1",
+        dry_run=False,
+        confirm=True,
+    )
+    assert out["dry_run"] is False
+    assert out["deleted"] == 2
+
+
+def test_run_scalar_count_dict_row(monkeypatch: pytest.MonkeyPatch) -> None:
+    cursor = MagicMock()
+    cursor.fetchone.return_value = {"C": 42}
+    conn = _mock_conn(cursor)
+    monkeypatch.setattr("nz_mcp.catalog.write.open_connection", lambda *_a, **_k: conn)
+    n = _run_scalar_count(_PROFILE, "pw", "SELECT 1", ())
+    assert n == 42
+
+
+def test_execute_insert_skip_ignores_duplicate(monkeypatch: pytest.MonkeyPatch) -> None:
+    cursor = MagicMock()
+    conn = _mock_conn(cursor)
+
+    def _exec(sql: str, params: tuple[Any, ...] | None = None) -> None:
+        if "INSERT" in sql and params and params[0] == 2:
+            msg = "duplicate key value violates unique constraint"
+            raise OSError(msg)
+
+    cursor.execute.side_effect = _exec
+
+    monkeypatch.setattr("nz_mcp.catalog.write.get_password", lambda _n: "pw")
+    monkeypatch.setattr("nz_mcp.catalog.write.open_connection", lambda *_a, **_k: conn)
+    rows = [{"A": 1}, {"A": 2}]
+    out = execute_insert(_PROFILE, "DEV", "PUBLIC", "TAB", rows, on_conflict="skip")
+    assert out["inserted"] == 1

--- a/tests/unit/test_tools_write.py
+++ b/tests/unit/test_tools_write.py
@@ -1,0 +1,214 @@
+"""Tests for write MCP tools."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from nz_mcp.server import call_tool
+from nz_mcp.tools.write import (
+    DeleteInput,
+    InsertInput,
+    UpdateInput,
+    nz_delete,
+    nz_insert,
+    nz_update,
+)
+
+
+def test_nz_insert_permission_denied_read_profile(two_profiles: Path) -> None:
+    out = call_tool(
+        "nz_insert",
+        {
+            "database": "DEV",
+            "schema": "PUBLIC",
+            "table": "T",
+            "rows": [{"A": 1}],
+        },
+        config_path=two_profiles,
+    )
+    assert "error" in out
+    assert out["error"]["code"] == "PERMISSION_DENIED"
+
+
+def test_nz_insert_happy(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    home = tmp_path / "nz-mcp"
+    home.mkdir()
+    profiles = home / "profiles.toml"
+    profiles.write_text(
+        'active = "w"\n[profiles.w]\nhost="h"\nport=5480\ndatabase="DEV"\nuser="u"\nmode="write"\n',
+        encoding="utf-8",
+    )
+    import nz_mcp.config as cfg
+
+    monkeypatch.setenv("NZ_MCP_HOME", str(home))
+    monkeypatch.setattr(cfg, "config_dir", lambda: home)
+
+    monkeypatch.setattr(
+        "nz_mcp.tools.write.execute_insert",
+        lambda *_a, **_k: {"inserted": 2, "duration_ms": 10},
+    )
+    out = nz_insert(
+        InsertInput(database="DEV", table_schema="PUBLIC", table="T", rows=[{"A": 1}, {"A": 2}]),
+        config_path=profiles,
+    )
+    assert out.inserted == 2
+
+
+def test_nz_update_output_dry_run(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    home = tmp_path / "nz-mcp"
+    home.mkdir()
+    profiles = home / "profiles.toml"
+    profiles.write_text(
+        'active = "w"\n[profiles.w]\nhost="h"\nport=5480\ndatabase="DEV"\nuser="u"\nmode="write"\n',
+        encoding="utf-8",
+    )
+    import nz_mcp.config as cfg
+
+    monkeypatch.setenv("NZ_MCP_HOME", str(home))
+    monkeypatch.setattr(cfg, "config_dir", lambda: home)
+    monkeypatch.setattr(
+        "nz_mcp.tools.write.execute_update",
+        lambda *_a, **_k: {
+            "updated": 0,
+            "would_update": 4,
+            "dry_run": True,
+            "confirm_required": True,
+            "duration_ms": 5,
+        },
+    )
+    out = nz_update(
+        UpdateInput(
+            database="DEV",
+            table_schema="PUBLIC",
+            table="T",
+            set={"X": 1},
+            where="ID > 0",
+        ),
+        config_path=profiles,
+    )
+    assert out.dry_run is True
+    assert out.would_update == 4
+
+
+def test_nz_delete_dry_run_mocked(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    home = tmp_path / "nz-mcp"
+    home.mkdir()
+    profiles = home / "profiles.toml"
+    profiles.write_text(
+        'active = "w"\n[profiles.w]\nhost="h"\nport=5480\ndatabase="DEV"\nuser="u"\nmode="write"\n'
+        "max_rows_default = 100\ntimeout_s_default = 30\n",
+        encoding="utf-8",
+    )
+    import nz_mcp.config as cfg
+
+    monkeypatch.setenv("NZ_MCP_HOME", str(home))
+    monkeypatch.setattr(cfg, "config_dir", lambda: home)
+    monkeypatch.setattr(
+        "nz_mcp.tools.write.execute_delete",
+        lambda *_a, **_k: {
+            "deleted": 0,
+            "would_delete": 9,
+            "dry_run": True,
+            "confirm_required": True,
+            "duration_ms": 2,
+        },
+    )
+    out = nz_delete(
+        DeleteInput(
+            database="DEV",
+            table_schema="PUBLIC",
+            table="T",
+            where="ID = 1",
+        ),
+        config_path=profiles,
+    )
+    assert out.would_delete == 9
+    assert out.dry_run is True
+
+
+def test_nz_update_applies_when_confirmed(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    home = tmp_path / "nz-mcp"
+    home.mkdir()
+    profiles = home / "profiles.toml"
+    profiles.write_text(
+        'active = "w"\n[profiles.w]\nhost="h"\nport=5480\ndatabase="DEV"\nuser="u"\nmode="write"\n'
+        "max_rows_default = 100\ntimeout_s_default = 30\n",
+        encoding="utf-8",
+    )
+    import nz_mcp.config as cfg
+
+    monkeypatch.setenv("NZ_MCP_HOME", str(home))
+    monkeypatch.setattr(cfg, "config_dir", lambda: home)
+    monkeypatch.setattr(
+        "nz_mcp.tools.write.execute_update",
+        lambda *_a, **_k: {"updated": 3, "dry_run": False, "duration_ms": 8},
+    )
+    out = nz_update(
+        UpdateInput(
+            database="DEV",
+            table_schema="PUBLIC",
+            table="T",
+            set={"X": 1},
+            where="ID = 1",
+            dry_run=False,
+            confirm=True,
+        ),
+        config_path=profiles,
+    )
+    assert out.updated == 3
+    assert out.dry_run is False
+
+
+def test_delete_input_strips_where() -> None:
+    d = DeleteInput(
+        database="DEV",
+        table_schema="PUBLIC",
+        table="T",
+        where="  ID = 2  ",
+    )
+    assert d.where == "ID = 2"
+
+
+def test_update_input_strips_where() -> None:
+    u = UpdateInput(
+        database="DEV",
+        table_schema="PUBLIC",
+        table="T",
+        set={"X": 1},
+        where="  ID = 1  ",
+    )
+    assert u.where == "ID = 1"
+
+
+def test_nz_delete_applies_when_confirmed(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    home = tmp_path / "nz-mcp"
+    home.mkdir()
+    profiles = home / "profiles.toml"
+    profiles.write_text(
+        'active = "w"\n[profiles.w]\nhost="h"\nport=5480\ndatabase="DEV"\nuser="u"\nmode="write"\n'
+        "max_rows_default = 100\ntimeout_s_default = 30\n",
+        encoding="utf-8",
+    )
+    import nz_mcp.config as cfg
+
+    monkeypatch.setenv("NZ_MCP_HOME", str(home))
+    monkeypatch.setattr(cfg, "config_dir", lambda: home)
+    monkeypatch.setattr(
+        "nz_mcp.tools.write.execute_delete",
+        lambda *_a, **_k: {"deleted": 4, "dry_run": False, "duration_ms": 1},
+    )
+    out = nz_delete(
+        DeleteInput(
+            database="DEV",
+            table_schema="PUBLIC",
+            table="T",
+            where="ID = 1",
+            dry_run=False,
+            confirm=True,
+        ),
+        config_path=profiles,
+    )
+    assert out.deleted == 4
+    assert out.dry_run is False


### PR DESCRIPTION
## ¿Qué cambia?

Implementa el paquete **write** (#48): `nz_insert`, `nz_update`, `nz_delete` con SQL parametrizado (`?`), validación `sql_guard` en modo `write` o `read` (COUNT en dry-run), `dry_run`/`confirm` para UPDATE/DELETE, y código `CONFIRM_REQUIRED` si falta confirmación.

## Issue relacionado

Closes #48

## Acción según AGENTS.md

- **Ruta**: nueva tool, sql_guard, escritura
- **Docs**: `docs/architecture/tools-contract.md`, `docs/architecture/security-model.md`, `docs/actions/add-tool.md`
- **Rol**: Backend Developer + Data Engineer

## Auditoría pre-merge — 7 dimensiones

### 1. Contrato y compatibilidad
- [x] `tools-contract.md` y `CHANGELOG.md` actualizados (ES/EN).

### 2. Seguridad
- [x] Todo SQL mutación pasa por `sql_guard.validate(..., mode="write")`; COUNT dry-run con `mode="read"`.
- [x] Valores vía placeholders; identificadores validados (`validate_catalog_identifier`).
- [x] `database` debe coincidir con el perfil (mismo patrón que sampling).

### 3. Mantenibilidad
- [x] `catalog/write.py` + `tools/write.py`; registro en `tools/__init__.py`.

### 4. Tests
- [x] Unit + guard adversarial UPDATE/DELETE sin WHERE; permiso read → PERMISSION_DENIED vía `call_tool`.
- [x] Cobertura global ≥ 85 %.

### 5. Tipado y estilo
- [x] `ruff` / `mypy` limpios.

### 6. Documentación
- [x] Mensaje i18n `CONFIRM_REQUIRED` ES/EN; `server.py` mapea código.

### 7. Idioma y forma
- [x] Commit conventional en español; rama `feat/48-write-package`.

## Validación humana requerida

- [x] No

## Notas para el auditor

- `on_conflict=skip`: inserción fila a fila; errores que parecen violación única se omiten (heurística por mensaje).
- UPDATE/DELETE: el predicado `where` forma parte del SQL validado por `sql_guard` (no placeholders en WHERE en esta versión).
