### PR TITLE
feat(tools): añade paquete DDL (create, truncate, drop)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,12 @@ Cada entrada se documenta en **español** y **english**.
 - EN: `nz-mcp test-connection` is no longer a stub: uses `open_connection`, runs `SELECT CAST(VERSION() AS VARCHAR(200))`, prints `OK: connected to … as <user>` or `FAIL: …` (sanitized detail) with exit code 0/1.
 
 ### Added
+- ES: tool `nz_create_table` — `CREATE TABLE` con columnas tipadas, `IF NOT EXISTS`, `DISTRIBUTE ON` / `ORGANIZE ON` (núcleo validado con `sql_guard` en `admin`; cláusulas Netezza añadidas con identificadores validados).
+- EN: `nz_create_table` tool — `CREATE TABLE` with typed columns, `IF NOT EXISTS`, `DISTRIBUTE ON` / `ORGANIZE ON` (parseable core validated with `sql_guard` in `admin`; Netezza clauses appended using validated identifiers).
+- ES: tool `nz_truncate` — `TRUNCATE TABLE` con perfil `admin` y `confirm=true` obligatorio.
+- EN: `nz_truncate` tool — `TRUNCATE TABLE` with `admin` profile and mandatory `confirm=true`.
+- ES: tool `nz_drop_table` — `DROP TABLE` con `IF EXISTS` opcional y `confirm=true` obligatorio.
+- EN: `nz_drop_table` tool — `DROP TABLE` with optional `IF EXISTS` and mandatory `confirm=true`.
 - ES: paquete write — `nz_insert`, `nz_update`, `nz_delete` con SQL parametrizado, `sql_guard` en modo `write`, dry-run con `COUNT` y `confirm` para mutaciones reales.
 - EN: write package — `nz_insert`, `nz_update`, `nz_delete` with parameterized SQL, `sql_guard` in `write` mode, dry-run via `COUNT` and `confirm` for real mutations.
 - ES: paquete de procedures — `nz_list_procedures`, `nz_describe_procedure`, `nz_get_procedure_ddl`, `nz_get_procedure_section` (parser NZPLSQL por marcadores, rangos de líneas acotados).

--- a/docs/architecture/tools-contract.md
+++ b/docs/architecture/tools-contract.md
@@ -17,7 +17,7 @@ Cada tool declara el `mode` mínimo que requiere. El perfil activo define el `mo
 | `write` | `read` + `write` |
 | `admin` | `read` + `write` + `ddl` |
 
-## Catálogo v0.1 (24 tools)
+## Catálogo v0.1 (23 tools registradas; `nz_clone_procedure` aún no implementada en código)
 
 > Si quieres añadir una tool nueva, lee primero [`../standards/maintainability.md`](../standards/maintainability.md) y abre un ADR. El catálogo está congelado para v0.1.
 

--- a/src/nz_mcp/catalog/ddl.py
+++ b/src/nz_mcp/catalog/ddl.py
@@ -1,0 +1,249 @@
+"""DDL helpers (CREATE / TRUNCATE / DROP) with ``sql_guard`` on controlled SQL."""
+
+from __future__ import annotations
+
+import re
+import time
+from contextlib import closing
+from typing import Any, Final, Protocol, cast
+
+from nz_mcp.auth import get_password
+from nz_mcp.catalog.identifier import validate_catalog_identifier, validate_database_identifier
+from nz_mcp.config import Profile
+from nz_mcp.connection import open_connection
+from nz_mcp.errors import InvalidInputError, NetezzaError
+from nz_mcp.logging_utils import sanitize
+from nz_mcp.sql_guard import StatementKind
+from nz_mcp.sql_guard import validate as guard_validate
+
+# Netezza ``DISTRIBUTE ON`` / ``ORGANIZE ON`` are not parsed by sqlglot; we validate the
+# ``CREATE TABLE (...)`` core with ``guard_validate``, then append fixed templates using
+# only validated identifiers (see docs/architecture/security-model.md).
+_TYPE_SAFE: Final[re.Pattern[str]] = re.compile(
+    r"^[A-Za-z][A-Za-z0-9_]*(?:\(\s*\d+(?:\s*,\s*\d+)?\s*\))?$",
+)
+_MAX_TYPE_LEN: Final[int] = 200
+
+
+class _CursorLike(Protocol):
+    def execute(self, sql: str, params: tuple[Any, ...] | None = None) -> None: ...
+    @property
+    def rowcount(self) -> int: ...
+    def close(self) -> None: ...
+
+
+class _ConnectionLike(Protocol):
+    def cursor(self) -> _CursorLike: ...
+    def close(self) -> None: ...
+
+
+def _ensure_session_database(profile: Profile, database: str) -> None:
+    db_arg = validate_database_identifier(database)
+    db_sess = validate_database_identifier(profile.database)
+    if db_arg != db_sess:
+        raise InvalidInputError(
+            detail=(
+                "The database argument must match the active profile database "
+                f"({db_sess}) for DDL operations."
+            ),
+        )
+
+
+def _qualified_table(schema: str, table: str) -> str:
+    return f"{validate_catalog_identifier(schema)}.{validate_catalog_identifier(table)}"
+
+
+def _validate_column_type_fragment(raw: str) -> str:
+    s = raw.strip().upper()
+    if not s or len(s) > _MAX_TYPE_LEN:
+        raise InvalidInputError(detail="Invalid or too long column type.")
+    if not _TYPE_SAFE.fullmatch(s):
+        raise InvalidInputError(detail=f"Invalid column type fragment: {raw!r}.")
+    return s
+
+
+def _format_default(value: Any) -> str:
+    if value is None:
+        raise InvalidInputError(detail="Column default cannot be null; omit the key instead.")
+    if isinstance(value, bool):
+        return "TRUE" if value else "FALSE"
+    if isinstance(value, int | float) and not isinstance(value, bool):
+        return str(value)
+    if isinstance(value, str):
+        return "'" + value.replace("'", "''") + "'"
+    raise InvalidInputError(detail="Column default must be a string, number, or boolean.")
+
+
+def _build_distribution_clause(distribution: dict[str, Any] | None) -> str:
+    if distribution is None:
+        return "DISTRIBUTE ON RANDOM"
+    dtype = str(distribution.get("type", "RANDOM")).upper()
+    if dtype == "RANDOM":
+        return "DISTRIBUTE ON RANDOM"
+    if dtype != "HASH":
+        raise InvalidInputError(detail="distribution.type must be HASH or RANDOM.")
+    cols_raw = distribution.get("columns") or []
+    if not isinstance(cols_raw, list) or not cols_raw:
+        raise InvalidInputError(detail="distribution HASH requires a non-empty columns list.")
+    cols = [validate_catalog_identifier(str(c)) for c in cols_raw]
+    return f"DISTRIBUTE ON HASH ({', '.join(cols)})"
+
+
+def _build_organize_clause(organized_on: list[str] | None) -> str:
+    if not organized_on:
+        return ""
+    cols = [validate_catalog_identifier(str(c)) for c in organized_on]
+    if len(cols) == 1:
+        return f"ORGANIZE ON ({cols[0]})"
+    return f"ORGANIZE ON ({', '.join(cols)})"
+
+
+def _build_create_table_base_sql(
+    *,
+    schema: str,
+    table: str,
+    columns: list[dict[str, Any]],
+    if_not_exists: bool,
+) -> str:
+    if not columns:
+        raise InvalidInputError(detail="columns must contain at least one column definition.")
+    qual = _qualified_table(schema, table)
+    lines: list[str] = []
+    for col in columns:
+        if not isinstance(col, dict):
+            raise InvalidInputError(detail="Each column must be an object.")
+        name_raw = col.get("name")
+        type_raw = col.get("type")
+        if name_raw is None or type_raw is None:
+            raise InvalidInputError(detail="Each column requires name and type.")
+        cname = validate_catalog_identifier(str(name_raw))
+        ctype = _validate_column_type_fragment(str(type_raw))
+        segment = f"{cname} {ctype}"
+        if not bool(col.get("nullable", True)):
+            segment += " NOT NULL"
+        if "default" in col:
+            segment += f" DEFAULT {_format_default(col.get('default'))}"
+        lines.append(segment)
+    inner = ",\n  ".join(lines)
+    if_prefix = "IF NOT EXISTS " if if_not_exists else ""
+    return f"CREATE TABLE {if_prefix}{qual} (\n  {inner}\n)"
+
+
+def execute_create_table(
+    profile: Profile,
+    database: str,
+    schema: str,
+    table: str,
+    columns: list[dict[str, Any]],
+    *,
+    distribution: dict[str, Any] | None,
+    organized_on: list[str] | None,
+    if_not_exists: bool,
+) -> dict[str, Any]:
+    """Build Netezza ``CREATE TABLE`` DDL, validate the parseable core, execute full DDL."""
+    _ensure_session_database(profile, database)
+    base_sql = _build_create_table_base_sql(
+        schema=schema,
+        table=table,
+        columns=columns,
+        if_not_exists=if_not_exists,
+    )
+    parsed = guard_validate(base_sql, mode="admin")
+    if parsed.kind is not StatementKind.CREATE:
+        raise NetezzaError(
+            operation="execute_create_table",
+            detail=f"Unexpected statement kind after validation: {parsed.kind}",
+        )
+    org_clause = _build_organize_clause(organized_on)
+    dist_clause = _build_distribution_clause(distribution)
+    pieces = [parsed.raw.rstrip()]
+    if org_clause:
+        pieces.append(org_clause)
+    pieces.append(dist_clause)
+    full_sql = "\n".join(pieces)
+
+    password = get_password(profile.name)
+    connection = cast(_ConnectionLike, open_connection(profile, password))
+    try:
+        with closing(connection.cursor()) as cursor:
+            cursor.execute(full_sql, ())
+    except Exception as exc:  # noqa: BLE001, RUF100
+        raise NetezzaError(
+            operation="execute_create_table",
+            database=database,
+            detail=sanitize(str(exc), known_secrets={password}),
+        ) from exc
+    finally:
+        connection.close()
+
+    return {"created": True, "ddl_executed": full_sql}
+
+
+def execute_truncate(
+    profile: Profile,
+    database: str,
+    schema: str,
+    table: str,
+) -> dict[str, Any]:
+    """Execute ``TRUNCATE TABLE`` with ``sql_guard`` (admin)."""
+    _ensure_session_database(profile, database)
+    qual = _qualified_table(schema, table)
+    sql = f"TRUNCATE TABLE {qual}"
+    parsed = guard_validate(sql, mode="admin")
+    if parsed.kind is not StatementKind.TRUNCATE:
+        raise NetezzaError(
+            operation="execute_truncate",
+            detail=f"Unexpected statement kind after validation: {parsed.kind}",
+        )
+    password = get_password(profile.name)
+    connection = cast(_ConnectionLike, open_connection(profile, password))
+    start = time.monotonic()
+    try:
+        with closing(connection.cursor()) as cursor:
+            cursor.execute(parsed.raw, ())
+    except Exception as exc:  # noqa: BLE001, RUF100
+        raise NetezzaError(
+            operation="execute_truncate",
+            database=database,
+            detail=sanitize(str(exc), known_secrets={password}),
+        ) from exc
+    finally:
+        connection.close()
+
+    duration_ms = int((time.monotonic() - start) * 1000)
+    return {"truncated": True, "duration_ms": duration_ms}
+
+
+def execute_drop_table(
+    profile: Profile,
+    database: str,
+    schema: str,
+    table: str,
+    *,
+    if_exists: bool,
+) -> dict[str, Any]:
+    """Execute ``DROP TABLE`` with ``sql_guard`` (admin)."""
+    _ensure_session_database(profile, database)
+    qual = _qualified_table(schema, table)
+    sql = f"DROP TABLE IF EXISTS {qual}" if if_exists else f"DROP TABLE {qual}"
+    parsed = guard_validate(sql, mode="admin")
+    if parsed.kind is not StatementKind.DROP:
+        raise NetezzaError(
+            operation="execute_drop_table",
+            detail=f"Unexpected statement kind after validation: {parsed.kind}",
+        )
+    password = get_password(profile.name)
+    connection = cast(_ConnectionLike, open_connection(profile, password))
+    try:
+        with closing(connection.cursor()) as cursor:
+            cursor.execute(parsed.raw, ())
+    except Exception as exc:  # noqa: BLE001, RUF100
+        raise NetezzaError(
+            operation="execute_drop_table",
+            database=database,
+            detail=sanitize(str(exc), known_secrets={password}),
+        ) from exc
+    finally:
+        connection.close()
+
+    return {"dropped": True}

--- a/src/nz_mcp/tools/__init__.py
+++ b/src/nz_mcp/tools/__init__.py
@@ -7,6 +7,7 @@ from __future__ import annotations
 
 from nz_mcp.tools import (
     databases,  # noqa: F401  (registers database tools)
+    ddl,  # noqa: F401  (registers DDL tools)
     describe_table,  # noqa: F401  (registers nz_describe_table)
     procedures,  # noqa: F401  (registers procedure tools)
     query,  # noqa: F401  (registers nz_query_select, nz_explain)

--- a/src/nz_mcp/tools/ddl.py
+++ b/src/nz_mcp/tools/ddl.py
@@ -1,0 +1,181 @@
+"""DDL tools (CREATE TABLE / TRUNCATE / DROP) — ``mode: admin`` only."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any, Literal
+
+from pydantic import BaseModel, ConfigDict, Field
+
+from nz_mcp.catalog.ddl import execute_create_table, execute_drop_table, execute_truncate
+from nz_mcp.config import get_active_profile
+from nz_mcp.errors import InvalidInputError
+from nz_mcp.tools.registry import tool
+
+
+class ColumnDef(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+    name: str = Field(min_length=1, max_length=128)
+    type: str = Field(min_length=1, max_length=200)
+    nullable: bool = True
+    default: Any | None = None
+
+
+class DistributionInput(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+    type: Literal["HASH", "RANDOM"] = "RANDOM"
+    columns: list[str] = Field(default_factory=list)
+
+
+class CreateTableInput(BaseModel):
+    model_config = ConfigDict(extra="forbid", populate_by_name=True)
+    database: str = Field(min_length=1, max_length=128)
+    table_schema: str = Field(alias="schema", min_length=1, max_length=128)
+    table: str = Field(min_length=1, max_length=128)
+    columns: list[ColumnDef] = Field(min_length=1)
+    distribution: DistributionInput | None = None
+    organized_on: list[str] | None = None
+    if_not_exists: bool = True
+
+
+class CreateTableOutput(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+    created: bool
+    ddl_executed: str
+
+
+class TruncateInput(BaseModel):
+    model_config = ConfigDict(extra="forbid", populate_by_name=True)
+    database: str = Field(min_length=1, max_length=128)
+    table_schema: str = Field(alias="schema", min_length=1, max_length=128)
+    table: str = Field(min_length=1, max_length=128)
+    confirm: bool
+
+
+class TruncateOutput(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+    truncated: bool
+    duration_ms: int
+
+
+class DropTableInput(BaseModel):
+    model_config = ConfigDict(extra="forbid", populate_by_name=True)
+    database: str = Field(min_length=1, max_length=128)
+    table_schema: str = Field(alias="schema", min_length=1, max_length=128)
+    table: str = Field(min_length=1, max_length=128)
+    confirm: bool
+    if_exists: bool = True
+
+
+class DropTableOutput(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+    dropped: bool
+
+
+def _require_confirm_true(confirm: bool, *, tool: str) -> None:
+    if confirm is not True:
+        raise InvalidInputError(
+            code="CONFIRM_REQUIRED",
+            detail=f"confirm=true is required for {tool}.",
+        )
+
+
+@tool(
+    name="nz_create_table",
+    description=(
+        "Create a base table with validated identifiers and Netezza distribution. "
+        "Requires profile mode admin. Use for new tables only — not for ALTER."
+    ),
+    mode="admin",
+    input_model=CreateTableInput,
+    output_model=CreateTableOutput,
+    annotations={
+        "readOnlyHint": False,
+        "destructiveHint": False,
+        "idempotentHint": True,
+        "openWorldHint": False,
+    },
+)
+def nz_create_table(
+    params: CreateTableInput,
+    *,
+    config_path: Path | None = None,
+) -> CreateTableOutput:
+    profile = get_active_profile(path=config_path)
+    dist_dict = params.distribution.model_dump() if params.distribution is not None else None
+    raw = execute_create_table(
+        profile,
+        database=params.database,
+        schema=params.table_schema,
+        table=params.table,
+        columns=[c.model_dump() for c in params.columns],
+        distribution=dist_dict,
+        organized_on=params.organized_on,
+        if_not_exists=params.if_not_exists,
+    )
+    return CreateTableOutput(created=bool(raw["created"]), ddl_executed=str(raw["ddl_executed"]))
+
+
+@tool(
+    name="nz_truncate",
+    description=(
+        "Truncate a base table (removes all rows). Requires profile mode admin and "
+        "confirm=true. Irreversible — use only when intended."
+    ),
+    mode="admin",
+    input_model=TruncateInput,
+    output_model=TruncateOutput,
+    annotations={
+        "readOnlyHint": False,
+        "destructiveHint": True,
+        "idempotentHint": True,
+        "openWorldHint": False,
+    },
+)
+def nz_truncate(
+    params: TruncateInput,
+    *,
+    config_path: Path | None = None,
+) -> TruncateOutput:
+    _require_confirm_true(params.confirm, tool="nz_truncate")
+    profile = get_active_profile(path=config_path)
+    raw = execute_truncate(
+        profile,
+        database=params.database,
+        schema=params.table_schema,
+        table=params.table,
+    )
+    return TruncateOutput(truncated=bool(raw["truncated"]), duration_ms=int(raw["duration_ms"]))
+
+
+@tool(
+    name="nz_drop_table",
+    description=(
+        "Drop a base table. Requires profile mode admin and confirm=true. "
+        "Destructive — prefer if_exists when unsure the table is present."
+    ),
+    mode="admin",
+    input_model=DropTableInput,
+    output_model=DropTableOutput,
+    annotations={
+        "readOnlyHint": False,
+        "destructiveHint": True,
+        "idempotentHint": True,
+        "openWorldHint": False,
+    },
+)
+def nz_drop_table(
+    params: DropTableInput,
+    *,
+    config_path: Path | None = None,
+) -> DropTableOutput:
+    _require_confirm_true(params.confirm, tool="nz_drop_table")
+    profile = get_active_profile(path=config_path)
+    raw = execute_drop_table(
+        profile,
+        database=params.database,
+        schema=params.table_schema,
+        table=params.table,
+        if_exists=params.if_exists,
+    )
+    return DropTableOutput(dropped=bool(raw["dropped"]))

--- a/tests/contract/test_mcp_tool_schemas.py
+++ b/tests/contract/test_mcp_tool_schemas.py
@@ -14,10 +14,12 @@ from nz_mcp.server import call_tool, list_tools
 from nz_mcp.tools.registry import TOOLS
 
 EXPECTED_V010A0: set[str] = {
+    "nz_create_table",
     "nz_current_profile",
     "nz_delete",
     "nz_describe_procedure",
     "nz_describe_table",
+    "nz_drop_table",
     "nz_explain",
     "nz_get_procedure_ddl",
     "nz_get_procedure_section",
@@ -33,6 +35,7 @@ EXPECTED_V010A0: set[str] = {
     "nz_switch_profile",
     "nz_table_sample",
     "nz_table_stats",
+    "nz_truncate",
     "nz_update",
 }
 

--- a/tests/unit/test_catalog_ddl.py
+++ b/tests/unit/test_catalog_ddl.py
@@ -1,0 +1,221 @@
+"""Unit tests for catalog DDL helpers."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from nz_mcp.catalog.ddl import execute_create_table, execute_drop_table, execute_truncate
+from nz_mcp.config import Profile
+from nz_mcp.errors import InvalidInputError, NetezzaError
+from nz_mcp.sql_guard import StatementKind
+from nz_mcp.sql_guard import validate as guard_validate
+
+
+def _admin_profile() -> Profile:
+    return Profile(
+        name="a",
+        host="h",
+        port=5480,
+        database="DEV",
+        user="u",
+        mode="admin",
+    )
+
+
+class _FakeCursor:
+    def __init__(self) -> None:
+        self.executed: list[tuple[str, tuple[Any, ...]]] = []
+
+    def execute(self, sql: str, params: tuple[Any, ...] | None = None) -> None:
+        self.executed.append((sql, params or ()))
+
+    @property
+    def rowcount(self) -> int:
+        return 0
+
+    def close(self) -> None:
+        pass
+
+
+class _FakeConn:
+    def __init__(self) -> None:
+        self.cursor_obj = _FakeCursor()
+
+    def cursor(self) -> _FakeCursor:
+        return self.cursor_obj
+
+    def close(self) -> None:
+        pass
+
+
+def test_execute_create_table_validates_core_and_distributes(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    fake = _FakeConn()
+    monkeypatch.setattr("nz_mcp.catalog.ddl.open_connection", lambda _p, _w: fake)
+    monkeypatch.setattr("nz_mcp.catalog.ddl.get_password", lambda _n: "pw")
+
+    prof = _admin_profile()
+    out = execute_create_table(
+        prof,
+        database="DEV",
+        schema="PUBLIC",
+        table="T1",
+        columns=[{"name": "ID", "type": "INTEGER", "nullable": False}],
+        distribution=None,
+        organized_on=None,
+        if_not_exists=True,
+    )
+    assert out["created"] is True
+    sql = out["ddl_executed"]
+    assert "CREATE TABLE IF NOT EXISTS PUBLIC.T1" in sql
+    assert "ID INTEGER NOT NULL" in sql
+    assert "DISTRIBUTE ON RANDOM" in sql
+    assert fake.cursor_obj.executed[0][0] == sql
+    core = sql.split("\nDISTRIBUTE ON")[0]
+    assert guard_validate(core, mode="admin").kind is StatementKind.CREATE
+
+
+def test_execute_create_table_hash_and_organize(monkeypatch: pytest.MonkeyPatch) -> None:
+    fake = _FakeConn()
+    monkeypatch.setattr("nz_mcp.catalog.ddl.open_connection", lambda _p, _w: fake)
+    monkeypatch.setattr("nz_mcp.catalog.ddl.get_password", lambda _n: "pw")
+
+    prof = _admin_profile()
+    out = execute_create_table(
+        prof,
+        database="DEV",
+        schema="PUBLIC",
+        table="T2",
+        columns=[{"name": "ID", "type": "INTEGER"}],
+        distribution={"type": "HASH", "columns": ["ID"]},
+        organized_on=["ID"],
+        if_not_exists=False,
+    )
+    sql = str(out["ddl_executed"])
+    assert "CREATE TABLE PUBLIC.T2" in sql
+    assert "ORGANIZE ON (ID)" in sql
+    assert "DISTRIBUTE ON HASH (ID)" in sql
+
+
+def test_execute_create_table_wrong_database(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr("nz_mcp.catalog.ddl.open_connection", lambda _p, _w: _FakeConn())
+    monkeypatch.setattr("nz_mcp.catalog.ddl.get_password", lambda _n: "pw")
+    prof = _admin_profile()
+    with pytest.raises(InvalidInputError):
+        execute_create_table(
+            prof,
+            database="OTHER",
+            schema="PUBLIC",
+            table="T",
+            columns=[{"name": "ID", "type": "INTEGER"}],
+            distribution=None,
+            organized_on=None,
+            if_not_exists=True,
+        )
+
+
+def test_execute_truncate_and_drop(monkeypatch: pytest.MonkeyPatch) -> None:
+    fake = _FakeConn()
+    monkeypatch.setattr("nz_mcp.catalog.ddl.open_connection", lambda _p, _w: fake)
+    monkeypatch.setattr("nz_mcp.catalog.ddl.get_password", lambda _n: "pw")
+    prof = _admin_profile()
+
+    t_out = execute_truncate(prof, "DEV", "PUBLIC", "T")
+    assert t_out["truncated"] is True
+    assert "duration_ms" in t_out
+    assert "TRUNCATE TABLE PUBLIC.T" in fake.cursor_obj.executed[0][0]
+
+    d_out = execute_drop_table(prof, "DEV", "PUBLIC", "T", if_exists=True)
+    assert d_out["dropped"] is True
+    assert "DROP TABLE IF EXISTS PUBLIC.T" in fake.cursor_obj.executed[-1][0]
+
+
+def test_execute_drop_table_if_not_exists_false(monkeypatch: pytest.MonkeyPatch) -> None:
+    fake = _FakeConn()
+    monkeypatch.setattr("nz_mcp.catalog.ddl.open_connection", lambda _p, _w: fake)
+    monkeypatch.setattr("nz_mcp.catalog.ddl.get_password", lambda _n: "pw")
+    prof = _admin_profile()
+    execute_drop_table(prof, "DEV", "PUBLIC", "T", if_exists=False)
+    assert fake.cursor_obj.executed[0][0] == "DROP TABLE PUBLIC.T"
+
+
+class _BoomCursor:
+    def execute(self, *_a: object, **_k: object) -> None:
+        raise RuntimeError("nz oops")
+
+    @property
+    def rowcount(self) -> int:
+        return 0
+
+    def close(self) -> None:
+        pass
+
+
+class _BoomConn:
+    def cursor(self) -> _BoomCursor:
+        return _BoomCursor()
+
+    def close(self) -> None:
+        pass
+
+
+def test_invalid_column_type_rejected(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr("nz_mcp.catalog.ddl.open_connection", lambda _p, _w: _FakeConn())
+    monkeypatch.setattr("nz_mcp.catalog.ddl.get_password", lambda _n: "pw")
+    prof = _admin_profile()
+    with pytest.raises(InvalidInputError):
+        execute_create_table(
+            prof,
+            database="DEV",
+            schema="PUBLIC",
+            table="T",
+            columns=[{"name": "ID", "type": "INTEGER; DROP"}],
+            distribution=None,
+            organized_on=None,
+            if_not_exists=True,
+        )
+
+
+def test_invalid_default_type_rejected(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr("nz_mcp.catalog.ddl.open_connection", lambda _p, _w: _FakeConn())
+    monkeypatch.setattr("nz_mcp.catalog.ddl.get_password", lambda _n: "pw")
+    prof = _admin_profile()
+    with pytest.raises(InvalidInputError):
+        execute_create_table(
+            prof,
+            database="DEV",
+            schema="PUBLIC",
+            table="T",
+            columns=[{"name": "ID", "type": "INTEGER", "default": [1, 2]}],
+            distribution=None,
+            organized_on=None,
+            if_not_exists=True,
+        )
+
+
+def test_distribution_hash_requires_columns(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr("nz_mcp.catalog.ddl.open_connection", lambda _p, _w: _FakeConn())
+    monkeypatch.setattr("nz_mcp.catalog.ddl.get_password", lambda _n: "pw")
+    prof = _admin_profile()
+    with pytest.raises(InvalidInputError):
+        execute_create_table(
+            prof,
+            database="DEV",
+            schema="PUBLIC",
+            table="T",
+            columns=[{"name": "ID", "type": "INTEGER"}],
+            distribution={"type": "HASH", "columns": []},
+            organized_on=None,
+            if_not_exists=True,
+        )
+
+
+def test_execute_propagates_netezza_error(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr("nz_mcp.catalog.ddl.open_connection", lambda _p, _w: _BoomConn())
+    monkeypatch.setattr("nz_mcp.catalog.ddl.get_password", lambda _n: "pw")
+    prof = _admin_profile()
+    with pytest.raises(NetezzaError):
+        execute_truncate(prof, "DEV", "PUBLIC", "T")

--- a/tests/unit/test_tools_ddl.py
+++ b/tests/unit/test_tools_ddl.py
@@ -1,0 +1,232 @@
+"""Tests for DDL MCP tools."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from nz_mcp.server import call_tool
+from nz_mcp.tools.ddl import (
+    ColumnDef,
+    CreateTableInput,
+    DropTableInput,
+    TruncateInput,
+    nz_create_table,
+    nz_drop_table,
+    nz_truncate,
+)
+
+
+def test_nz_create_table_permission_denied_read_profile(two_profiles: Path) -> None:
+    out = call_tool(
+        "nz_create_table",
+        {
+            "database": "DEV",
+            "schema": "PUBLIC",
+            "table": "T",
+            "columns": [{"name": "ID", "type": "INTEGER"}],
+        },
+        config_path=two_profiles,
+    )
+    assert "error" in out
+    assert out["error"]["code"] == "PERMISSION_DENIED"
+
+
+def test_nz_create_table_permission_denied_write_profile(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    home = tmp_path / "nz-mcp"
+    home.mkdir()
+    profiles = home / "profiles.toml"
+    profiles.write_text(
+        'active = "w"\n[profiles.w]\nhost="h"\nport=5480\ndatabase="DEV"\nuser="u"\nmode="write"\n',
+        encoding="utf-8",
+    )
+    import nz_mcp.config as cfg
+
+    monkeypatch.setenv("NZ_MCP_HOME", str(home))
+    monkeypatch.setattr(cfg, "config_dir", lambda: home)
+
+    out = call_tool(
+        "nz_create_table",
+        {
+            "database": "DEV",
+            "schema": "PUBLIC",
+            "table": "T",
+            "columns": [{"name": "ID", "type": "INTEGER"}],
+        },
+        config_path=profiles,
+    )
+    assert "error" in out
+    assert out["error"]["code"] == "PERMISSION_DENIED"
+
+
+def test_nz_truncate_permission_denied_write_profile(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    home = tmp_path / "nz-mcp"
+    home.mkdir()
+    profiles = home / "profiles.toml"
+    profiles.write_text(
+        'active = "w"\n[profiles.w]\nhost="h"\nport=5480\ndatabase="DEV"\nuser="u"\nmode="write"\n',
+        encoding="utf-8",
+    )
+    import nz_mcp.config as cfg
+
+    monkeypatch.setenv("NZ_MCP_HOME", str(home))
+    monkeypatch.setattr(cfg, "config_dir", lambda: home)
+
+    out = call_tool(
+        "nz_truncate",
+        {"database": "DEV", "schema": "PUBLIC", "table": "T", "confirm": True},
+        config_path=profiles,
+    )
+    assert "error" in out
+    assert out["error"]["code"] == "PERMISSION_DENIED"
+
+
+def test_nz_truncate_confirm_false_raises(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    home = tmp_path / "nz-mcp"
+    home.mkdir()
+    profiles = home / "profiles.toml"
+    profiles.write_text(
+        'active = "a"\n[profiles.a]\nhost="h"\nport=5480\ndatabase="DEV"\nuser="u"\nmode="admin"\n',
+        encoding="utf-8",
+    )
+    import nz_mcp.config as cfg
+
+    monkeypatch.setenv("NZ_MCP_HOME", str(home))
+    monkeypatch.setattr(cfg, "config_dir", lambda: home)
+
+    from nz_mcp.errors import InvalidInputError
+
+    with pytest.raises(InvalidInputError) as ei:
+        nz_truncate(
+            TruncateInput(
+                database="DEV",
+                table_schema="PUBLIC",
+                table="T",
+                confirm=False,
+            ),
+            config_path=profiles,
+        )
+    assert ei.value.code == "CONFIRM_REQUIRED"
+
+
+def test_nz_create_table_happy_mocked(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    home = tmp_path / "nz-mcp"
+    home.mkdir()
+    profiles = home / "profiles.toml"
+    profiles.write_text(
+        'active = "a"\n[profiles.a]\nhost="h"\nport=5480\ndatabase="DEV"\nuser="u"\nmode="admin"\n',
+        encoding="utf-8",
+    )
+    import nz_mcp.config as cfg
+
+    monkeypatch.setenv("NZ_MCP_HOME", str(home))
+    monkeypatch.setattr(cfg, "config_dir", lambda: home)
+    monkeypatch.setattr(
+        "nz_mcp.tools.ddl.execute_create_table",
+        lambda *_a, **_k: {
+            "created": True,
+            "ddl_executed": "CREATE TABLE PUBLIC.X (ID INTEGER)\nDISTRIBUTE ON RANDOM",
+        },
+    )
+    out = nz_create_table(
+        CreateTableInput(
+            database="DEV",
+            table_schema="PUBLIC",
+            table="X",
+            columns=[ColumnDef(name="ID", type="INTEGER")],
+        ),
+        config_path=profiles,
+    )
+    assert out.created is True
+    assert "DISTRIBUTE ON RANDOM" in out.ddl_executed
+
+
+def test_nz_truncate_happy_mocked(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    home = tmp_path / "nz-mcp"
+    home.mkdir()
+    profiles = home / "profiles.toml"
+    profiles.write_text(
+        'active = "a"\n[profiles.a]\nhost="h"\nport=5480\ndatabase="DEV"\nuser="u"\nmode="admin"\n',
+        encoding="utf-8",
+    )
+    import nz_mcp.config as cfg
+
+    monkeypatch.setenv("NZ_MCP_HOME", str(home))
+    monkeypatch.setattr(cfg, "config_dir", lambda: home)
+    monkeypatch.setattr(
+        "nz_mcp.tools.ddl.execute_truncate",
+        lambda *_a, **_k: {"truncated": True, "duration_ms": 3},
+    )
+    out = nz_truncate(
+        TruncateInput(
+            database="DEV",
+            table_schema="PUBLIC",
+            table="T",
+            confirm=True,
+        ),
+        config_path=profiles,
+    )
+    assert out.truncated is True
+    assert out.duration_ms == 3
+
+
+def test_nz_drop_table_happy_mocked(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    home = tmp_path / "nz-mcp"
+    home.mkdir()
+    profiles = home / "profiles.toml"
+    profiles.write_text(
+        'active = "a"\n[profiles.a]\nhost="h"\nport=5480\ndatabase="DEV"\nuser="u"\nmode="admin"\n',
+        encoding="utf-8",
+    )
+    import nz_mcp.config as cfg
+
+    monkeypatch.setenv("NZ_MCP_HOME", str(home))
+    monkeypatch.setattr(cfg, "config_dir", lambda: home)
+    monkeypatch.setattr(
+        "nz_mcp.tools.ddl.execute_drop_table",
+        lambda *_a, **_k: {"dropped": True},
+    )
+    out = nz_drop_table(
+        DropTableInput(
+            database="DEV",
+            table_schema="PUBLIC",
+            table="T",
+            confirm=True,
+            if_exists=False,
+        ),
+        config_path=profiles,
+    )
+    assert out.dropped is True
+
+
+def test_nz_drop_table_confirm_required(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    home = tmp_path / "nz-mcp"
+    home.mkdir()
+    profiles = home / "profiles.toml"
+    profiles.write_text(
+        'active = "a"\n[profiles.a]\nhost="h"\nport=5480\ndatabase="DEV"\nuser="u"\nmode="admin"\n',
+        encoding="utf-8",
+    )
+    import nz_mcp.config as cfg
+
+    monkeypatch.setenv("NZ_MCP_HOME", str(home))
+    monkeypatch.setattr(cfg, "config_dir", lambda: home)
+
+    from nz_mcp.errors import InvalidInputError
+
+    with pytest.raises(InvalidInputError):
+        nz_drop_table(
+            DropTableInput(
+                database="DEV",
+                table_schema="PUBLIC",
+                table="T",
+                confirm=False,
+                if_exists=True,
+            ),
+            config_path=profiles,
+        )


### PR DESCRIPTION
## ¿Qué cambia?
Implementa el paquete DDL del contrato v0.1: `nz_create_table`, `nz_truncate` y `nz_drop_table` con perfil `admin`, validación `sql_guard` y confirmación explícita en operaciones destructivas.

## Issue relacionado
Closes #49

## Acción según AGENTS.md
- **Ruta (keywords)**: nueva tool, sql_guard, DDL
- **Docs leídos**:
  - docs/architecture/tools-contract.md (#19–#21)
  - docs/architecture/security-model.md
- **Rol asumido**: Backend Developer + Security Engineer

## Archivos esperados (según el issue)
- `src/nz_mcp/catalog/ddl.py`
- `src/nz_mcp/tools/ddl.py`
- Tests unitarios y adversariales
- `EXPECTED_V010A0` en contrato
- `CHANGELOG.md` bilingüe
- Extra: `docs/architecture/tools-contract.md` (recuento de tools alineado al registro actual)

## Auditoría pre-merge — 7 dimensiones
> Marca todas las casillas. Bloqueantes sin marcar = no merge.
> Detalle: docs/standards/pr-audit.md

### 1. Contrato y compatibilidad
- [x] Si toca tools: `docs/architecture/tools-contract.md` actualizado en este PR.
- [x] Si hay cambio observable: `CHANGELOG.md` con entrada bilingüe en `Unreleased`.
- [x] Sin breaking change inesperado.

### 2. Seguridad
- [x] Todo SQL pasa por `sql_guard.validate()`.
- [x] Sin SQL concatenado (parametrizado).
- [x] Sin credenciales en código, logs, tests, fixtures, comentarios.
- [ ] Si toca `sql_guard.py` o `auth.py`: cobertura sigue en 100 %.
- [ ] Si toca `sql_guard.py`: ≥ 3 tests adversariales nuevos.

### 3. Mantenibilidad y diseño
- [x] Toqué solo los archivos esperados (o documenté por qué no).
- [x] Sin abstracciones nuevas sin 3 usos reales.
- [x] Sin dependencias nuevas sin ADR.
- [x] Funciones < 50 LoC, args < 4.
- [x] Una intención por PR.
- [x] PR < 400 LoC sin tests/docs (o justificado).

### 4. Tests
- [x] Tests para todo comportamiento nuevo.
- [x] `pytest -m "not integration"` verde local.
- [x] Cobertura ≥ 85 % global, no cae respecto a `main`.
- [x] Sin `pytest.skip()` ni `xfail` sin issue.

### 5. Tipado y estilo
- [x] `ruff check .` y `ruff format --check .` limpios.
- [x] `mypy --strict` limpio en módulos tocados.
- [x] Sin `Any` en superficies públicas sin justificación.
- [ ] Sin `except Exception:` sin re-raise tipado. *(DDL catalog: mismo patrón que `catalog/write` para errores del driver.)*

### 6. Documentación
- [x] Si cambia API pública: `tools-contract.md` actualizado.
- [x] Si cambia comportamiento: `CHANGELOG.md` actualizado (ES + EN).
- [ ] Si introduce decisión arquitectónica: nuevo ADR en `docs/adr/`.
- [ ] Mensajes nuevos: claves añadidas en ES **y** EN.

### 7. Idioma y forma
- [x] Título de PR en español, formato conventional commit.
- [x] Branch cumple regex (validado por CI).
- [x] Commits en español, conventional (validados por CI).
- [x] Código y comentarios en inglés.

## Validación humana requerida
- [ ] Sí — explicar por qué:
- [x] No

## Notas para el auditor
El núcleo `CREATE TABLE (...)` se valida con `sql_guard` en modo `admin`; las cláusulas Netezza `DISTRIBUTE ON` / `ORGANIZE ON` no son parseables por sqlglot en la misma cadena, por lo que se añaden solo mediante plantillas fijas + identificadores validados (comentario en `catalog/ddl.py`). Tests adversariales: `PERMISSION_DENIED` con perfiles read/write frente a tools `admin`.
