### PR TITLE
fix: v0.1 alpha hardening (#69)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,20 @@ Cada entrada se documenta en **español** y **english**.
 
 ## [Unreleased]
 
+### Fixed
+- ES: el catálogo acepta filas devueltas como ``list`` (nzpy) además de ``tuple``; helper compartido ``is_sequence_row`` en consultas a ``_v_*``.
+- EN: catalog parsing accepts nzpy ``list`` rows as well as ``tuple`` rows; shared ``is_sequence_row`` helper for ``_v_*`` queries.
+- ES: dependencia ``typer>=0.15`` para compatibilidad con **click 8.2** (CLI sin errores de import).
+- EN: bumped **typer** to ``>=0.15`` for **click 8.2** compatibility (CLI import errors fixed).
+- ES: ``nz_explain`` / ``fetch_explain_text`` — si no hay result set y nzpy lanza ``ProgrammingError``, se concatena el plan desde ``cursor.notices``.
+- EN: ``nz_explain`` / ``fetch_explain_text`` — when there is no rowset and nzpy raises ``ProgrammingError``, plan text is taken from ``cursor.notices``.
+- ES: metadatos de columnas en ``execute_select`` mapean OIDs comunes a nombres legibles (p. ej. ``integer``, ``varchar``).
+- EN: ``execute_select`` column metadata maps common type OIDs to readable names (e.g. ``integer``, ``varchar``).
+- ES: ``resolve_locale()`` usa también ``locale.getdefaultlocale()`` cuando faltan ``LANG`` / ``NZ_MCP_LANG`` (útil en Windows).
+- EN: ``resolve_locale()`` also consults ``locale.getdefaultlocale()`` when ``LANG`` / ``NZ_MCP_LANG`` are unset (helps on Windows).
+- ES: textos de ``help=`` en CLI (p. ej. ``add-profile``, ``test-connection``) unificados en inglés.
+- EN: CLI ``help=`` strings (e.g. ``add-profile``, ``test-connection``) standardized to English.
+
 ### Security
 - ES: los mensajes de error del driver en `open_connection`, `list_databases` y `probe-catalog` pasan por `sanitize()` con `known_secrets` para no filtrar contraseñas en el `detail` expuesto al cliente MCP.
 - EN: driver error messages in `open_connection`, `list_databases`, and `probe-catalog` are passed through `sanitize()` with `known_secrets` so passwords are not leaked in MCP-exposed `detail` fields.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,7 @@ dependencies = [
     "sqlglot>=25.0",
     "keyring>=25.0",
     "structlog>=24.1",
-    "typer>=0.12",
+    "typer>=0.15",
 ]
 
 [project.optional-dependencies]

--- a/src/nz_mcp/catalog/databases.py
+++ b/src/nz_mcp/catalog/databases.py
@@ -8,6 +8,7 @@ from typing import Any, Final, Protocol, cast
 from nz_mcp.auth import get_password
 from nz_mcp.catalog.identifier import render_cross_db
 from nz_mcp.catalog.resolver import resolve_query
+from nz_mcp.catalog.row_shape import is_sequence_row
 from nz_mcp.config import Profile
 from nz_mcp.connection import open_connection
 from nz_mcp.errors import NetezzaError
@@ -61,6 +62,6 @@ def _row_to_database(row: Any) -> dict[str, str]:
                 detail="Catalog query must return DATABASE and OWNER columns.",
             )
         return {"name": str(row["DATABASE"]), "owner": str(row["OWNER"])}
-    if isinstance(row, tuple) and len(row) >= _DATABASE_ROW_MIN_ITEMS:
+    if is_sequence_row(row, _DATABASE_ROW_MIN_ITEMS):
         return {"name": str(row[0]), "owner": str(row[1])}
     raise NetezzaError(operation="list_databases", detail="Unexpected row shape from _v_database")

--- a/src/nz_mcp/catalog/execute.py
+++ b/src/nz_mcp/catalog/execute.py
@@ -8,6 +8,7 @@ from contextlib import closing
 from typing import Any, Final, Protocol, cast
 
 import sqlglot
+from nzpy import ProgrammingError
 from sqlglot import expressions as exp
 
 from nz_mcp.auth import get_password
@@ -18,6 +19,23 @@ from nz_mcp.logging_utils import sanitize
 
 FETCH_BATCH: Final[int] = 200
 RESPONSE_BYTES_CAP: Final[int] = 100 * 1024
+
+# Common PostgreSQL / Netezza type OIDs (driver may return OID ints in cursor.description).
+_TYPE_OID_TO_NAME: Final[dict[int, str]] = {
+    16: "bool",
+    19: "name",
+    20: "bigint",
+    21: "smallint",
+    23: "integer",
+    25: "text",
+    700: "real",
+    701: "double precision",
+    1042: "char",
+    1043: "varchar",
+    1082: "date",
+    1114: "timestamp",
+    1700: "numeric",
+}
 
 
 class _CursorLike(Protocol):
@@ -127,20 +145,34 @@ def execute_select(
 
 
 def fetch_explain_text(profile: Profile, explain_sql: str) -> str:
-    """Execute ``EXPLAIN`` / ``EXPLAIN VERBOSE`` and return plan text."""
+    """Execute ``EXPLAIN`` / ``EXPLAIN VERBOSE`` and return plan text.
+
+    On some NPS versions the plan is delivered as server notices (no row description);
+    nzpy then raises ``ProgrammingError: no result set`` on fetch — we join ``cursor.notices``.
+    """
     password = get_password(profile.name)
     connection = cast(_ConnectionLike, open_connection(profile, password))
     chunks: list[str] = []
     try:
         with closing(connection.cursor()) as cursor:
             cursor.execute(explain_sql)
-            while True:
-                batch = cursor.fetchmany(FETCH_BATCH)
-                if not batch:
-                    break
-                for raw in batch:
-                    cell = (raw[0] if raw else "") if isinstance(raw, (tuple, list)) else raw
-                    chunks.append("" if cell is None else str(cell))
+            try:
+                while True:
+                    batch = cursor.fetchmany(FETCH_BATCH)
+                    if not batch:
+                        break
+                    for raw in batch:
+                        cell = (raw[0] if raw else "") if isinstance(raw, (tuple, list)) else raw
+                        chunks.append("" if cell is None else str(cell))
+            except ProgrammingError as exc:
+                if "no result set" not in str(exc).lower():
+                    raise
+            if chunks:
+                return "\n".join(chunks).strip()
+            notice_texts = list(getattr(cursor, "notices", None) or [])
+            if notice_texts:
+                return "\n".join(n.strip() for n in notice_texts if n).strip()
+            return ""
     except Exception as exc:  # noqa: BLE001, RUF100
         raise NetezzaError(
             operation="explain",
@@ -150,7 +182,16 @@ def fetch_explain_text(profile: Profile, explain_sql: str) -> str:
     finally:
         connection.close()
 
-    return "\n".join(chunks).strip()
+
+def _type_label_from_oid_cell(cell: Any) -> str:
+    if isinstance(cell, int):
+        return _TYPE_OID_TO_NAME.get(cell, str(cell))
+    if isinstance(cell, str) and cell.isdigit():
+        oid = int(cell)
+        return _TYPE_OID_TO_NAME.get(oid, cell)
+    if cell is None:
+        return "unknown"
+    return str(cell)
 
 
 def _column_meta_from_cursor(cursor: _CursorLike) -> list[dict[str, str]]:
@@ -162,9 +203,9 @@ def _column_meta_from_cursor(cursor: _CursorLike) -> list[dict[str, str]]:
     for col in desc:
         if isinstance(col, (tuple, list)) and len(col) >= _min_parts:
             name = str(col[0]) if col[0] is not None else ""
-            ctype = str(col[1]) if len(col) > 1 and col[1] is not None else "unknown"
+            ctype = _type_label_from_oid_cell(col[1])
             out.append({"name": name, "type": ctype})
-        elif isinstance(col, tuple):
+        elif isinstance(col, (tuple, list)) and len(col) >= 1:
             out.append({"name": str(col[0]), "type": "unknown"})
         else:
             out.append({"name": str(col), "type": "unknown"})

--- a/src/nz_mcp/catalog/procedures.py
+++ b/src/nz_mcp/catalog/procedures.py
@@ -15,6 +15,7 @@ from nz_mcp.catalog.nzplsql_parser import (
     parse_sections,
 )
 from nz_mcp.catalog.resolver import resolve_query
+from nz_mcp.catalog.row_shape import is_sequence_row
 from nz_mcp.config import Profile
 from nz_mcp.connection import open_connection
 from nz_mcp.errors import (
@@ -350,7 +351,7 @@ def _row_to_list_item(row: Any) -> dict[str, str]:
             "arguments": "" if args is None else str(args),
             "returns": "" if ret is None else str(ret),
         }
-    if isinstance(row, tuple) and len(row) >= _ROW_LIST_MIN:
+    if is_sequence_row(row, _ROW_LIST_MIN):
         return {
             "name": str(row[0]),
             "owner": str(row[1]),
@@ -369,7 +370,7 @@ def _ddl_get(row: Any, field: str) -> str:
                 return str(row[k])
         return ""
     idx = _DDL_TUPLE_INDEX.get(field)
-    if idx is not None and isinstance(row, tuple) and len(row) > idx:
+    if idx is not None and is_sequence_row(row, idx + 1):
         cell = row[idx]
         return "" if cell is None else str(cell)
     return ""

--- a/src/nz_mcp/catalog/row_shape.py
+++ b/src/nz_mcp/catalog/row_shape.py
@@ -1,0 +1,11 @@
+"""Row-shape helpers for catalog row parsing.
+
+nzpy ``fetchall`` may return list cells (not only tuples) in the outer sequence.
+"""
+
+from __future__ import annotations
+
+
+def is_sequence_row(row: object, min_len: int) -> bool:
+    """True if ``row`` is list/tuple with at least ``min_len`` cells (not ``str``/``bytes``)."""
+    return isinstance(row, (tuple, list)) and len(row) >= min_len

--- a/src/nz_mcp/catalog/schemas.py
+++ b/src/nz_mcp/catalog/schemas.py
@@ -8,6 +8,7 @@ from typing import Any, Final, Protocol, cast
 from nz_mcp.auth import get_password
 from nz_mcp.catalog.identifier import render_cross_db
 from nz_mcp.catalog.resolver import resolve_query
+from nz_mcp.catalog.row_shape import is_sequence_row
 from nz_mcp.config import Profile
 from nz_mcp.connection import open_connection
 from nz_mcp.errors import NetezzaError
@@ -63,6 +64,6 @@ def _row_to_schema(row: Any) -> dict[str, str]:
                 detail="Catalog query must return SCHEMA and OWNER columns.",
             )
         return {"name": str(row["SCHEMA"]), "owner": str(row["OWNER"])}
-    if isinstance(row, tuple) and len(row) >= _SCHEMA_ROW_MIN_ITEMS:
+    if is_sequence_row(row, _SCHEMA_ROW_MIN_ITEMS):
         return {"name": str(row[0]), "owner": str(row[1])}
     raise NetezzaError(operation="list_schemas", detail="Unexpected row shape from _v_schema")

--- a/src/nz_mcp/catalog/tables.py
+++ b/src/nz_mcp/catalog/tables.py
@@ -16,6 +16,7 @@ from nz_mcp.catalog.identifier import (
     validate_database_identifier,
 )
 from nz_mcp.catalog.resolver import resolve_query
+from nz_mcp.catalog.row_shape import is_sequence_row
 from nz_mcp.config import Profile
 from nz_mcp.connection import open_connection
 from nz_mcp.errors import InvalidInputError, NetezzaError, ObjectNotFoundError
@@ -104,7 +105,7 @@ def _row_to_table(row: Any) -> dict[str, str]:
                 detail="Catalog query must return NAME (or TABLENAME) column.",
             )
         return {"name": str(row[name_key]), "kind": _TABLE_KIND}
-    if isinstance(row, tuple) and len(row) >= _TABLE_ROW_MIN_ITEMS:
+    if is_sequence_row(row, _TABLE_ROW_MIN_ITEMS):
         return {"name": str(row[0]), "kind": _TABLE_KIND}
     raise NetezzaError(operation="list_tables", detail="Unexpected row shape from _v_table")
 
@@ -200,7 +201,7 @@ def _distribution_pair(row: Any) -> tuple[str, int]:
                 detail="Distribution row must include ATTNAME and DISTSEQNO.",
             )
         return str(att), int(seq)
-    if isinstance(row, tuple) and len(row) >= _DIST_ROW_MIN:
+    if is_sequence_row(row, _DIST_ROW_MIN):
         return str(row[0]), int(row[1])
     raise NetezzaError(operation="describe_table", detail="Unexpected distribution row shape.")
 
@@ -222,7 +223,7 @@ def _column_descriptor(row: Any) -> dict[str, Any]:
             "nullable": not _is_not_null(not_null),
             "default": None if default is None else str(default),
         }
-    if isinstance(row, tuple) and len(row) >= _COL_TUPLE_MIN:
+    if is_sequence_row(row, _COL_TUPLE_MIN):
         default_val = row[3]
         return {
             "name": str(row[0]),
@@ -265,7 +266,7 @@ def _pk_triplet(row: Any) -> tuple[str, str, int]:
                 detail="Primary key row must include CONSTRAINTNAME, ATTNAME, CONSEQ.",
             )
         return str(c), str(a), int(s)
-    if isinstance(row, tuple) and len(row) >= _PK_TUPLE_MIN:
+    if is_sequence_row(row, _PK_TUPLE_MIN):
         return str(row[0]), str(row[1]), int(row[2])
     raise NetezzaError(operation="describe_table", detail="Unexpected primary key row shape.")
 
@@ -301,7 +302,7 @@ def _fk_constraint_name(row: Any) -> str:
         if v is None:
             raise NetezzaError(operation="describe_table", detail="FK row missing CONSTRAINTNAME.")
         return str(v)
-    if isinstance(row, tuple) and len(row) >= 1:
+    if is_sequence_row(row, 1):
         return str(row[0])
     raise NetezzaError(operation="describe_table", detail="Unexpected FK row shape.")
 
@@ -312,7 +313,7 @@ def _fk_conseq(row: Any) -> int:
         if s is None:
             raise NetezzaError(operation="describe_table", detail="FK row missing CONSEQ.")
         return int(s)
-    if isinstance(row, tuple) and len(row) >= _PK_TUPLE_MIN:
+    if is_sequence_row(row, _PK_TUPLE_MIN):
         return int(row[2])
     raise NetezzaError(operation="describe_table", detail="Unexpected FK row shape.")
 
@@ -323,7 +324,7 @@ def _fk_local_column(row: Any) -> str:
         if v is None:
             raise NetezzaError(operation="describe_table", detail="FK row missing ATTNAME.")
         return str(v)
-    if isinstance(row, tuple) and len(row) >= _DIST_ROW_MIN:
+    if is_sequence_row(row, _DIST_ROW_MIN):
         return str(row[1])
     raise NetezzaError(operation="describe_table", detail="Unexpected FK row shape.")
 
@@ -333,7 +334,7 @@ def _fk_ref_database(row: Any) -> str | None:
     if isinstance(row, dict):
         val = row.get(key)
         return None if val is None else str(val)
-    if isinstance(row, tuple) and len(row) >= _FK_PK_MIN:
+    if is_sequence_row(row, _FK_PK_MIN):
         val = row[3]
         return None if val is None else str(val)
     raise NetezzaError(operation="describe_table", detail="Unexpected FK row shape.")
@@ -346,7 +347,7 @@ def _fk_ref_schema(row: Any) -> str:
         if v is None:
             raise NetezzaError(operation="describe_table", detail="FK row missing PKSCHEMA.")
         return str(v)
-    if isinstance(row, tuple) and len(row) >= _FK_SCHEMA_MIN:
+    if is_sequence_row(row, _FK_SCHEMA_MIN):
         return str(row[4])
     raise NetezzaError(operation="describe_table", detail="Unexpected FK row shape.")
 
@@ -358,7 +359,7 @@ def _fk_ref_table(row: Any) -> str:
         if v is None:
             raise NetezzaError(operation="describe_table", detail="FK row missing PKRELATION.")
         return str(v)
-    if isinstance(row, tuple) and len(row) >= _FK_REL_MIN:
+    if is_sequence_row(row, _FK_REL_MIN):
         return str(row[5])
     raise NetezzaError(operation="describe_table", detail="Unexpected FK row shape.")
 
@@ -370,7 +371,7 @@ def _fk_ref_column(row: Any) -> str:
         if v is None:
             raise NetezzaError(operation="describe_table", detail="FK row missing PKATTNAME.")
         return str(v)
-    if isinstance(row, tuple) and len(row) >= _FK_ATT_MIN:
+    if is_sequence_row(row, _FK_ATT_MIN):
         return str(row[6])
     raise NetezzaError(operation="describe_table", detail="Unexpected FK row shape.")
 
@@ -483,7 +484,7 @@ def _parse_table_stats_row(row: Any) -> dict[str, Any]:
         alloc = pick("SIZE_BYTES_ALLOCATED")
         skew = pick("SKEW")
         created = pick("TABLE_CREATED")
-    elif isinstance(row, tuple) and len(row) >= _STATS_ROW_MIN:
+    elif is_sequence_row(row, _STATS_ROW_MIN):
         rc, used, alloc, skew, created = (
             row[0],
             row[1],

--- a/src/nz_mcp/catalog/views.py
+++ b/src/nz_mcp/catalog/views.py
@@ -8,6 +8,7 @@ from typing import Any, Final, Protocol, cast
 from nz_mcp.auth import get_password
 from nz_mcp.catalog.identifier import render_cross_db
 from nz_mcp.catalog.resolver import resolve_query
+from nz_mcp.catalog.row_shape import is_sequence_row
 from nz_mcp.config import Profile
 from nz_mcp.connection import open_connection
 from nz_mcp.errors import NetezzaError
@@ -124,7 +125,7 @@ def _row_to_view_list_item(row: Any) -> dict[str, str]:
                 detail="Catalog query must return NAME (or VIEWNAME) and OWNER columns.",
             )
         return {"name": str(row[name_key]), "owner": str(row["OWNER"])}
-    if isinstance(row, tuple) and len(row) >= _VIEW_LIST_MIN_ITEMS:
+    if is_sequence_row(row, _VIEW_LIST_MIN_ITEMS):
         return {"name": str(row[0]), "owner": str(row[1])}
     raise NetezzaError(operation="list_views", detail="Unexpected row shape from _v_view")
 
@@ -138,7 +139,7 @@ def _row_to_definition(row: Any) -> str:
             )
         text = row["DEFINITION"]
         return "" if text is None else str(text)
-    if isinstance(row, tuple) and len(row) >= 1:
+    if is_sequence_row(row, 1):
         cell = row[0]
         return "" if cell is None else str(cell)
     raise NetezzaError(operation="get_view_ddl", detail="Unexpected row shape from _v_view")

--- a/src/nz_mcp/cli.py
+++ b/src/nz_mcp/cli.py
@@ -71,8 +71,12 @@ def init_cmd() -> None:
 
 @app.command("add-profile")
 def add_profile_cmd(
-    name: str = typer.Argument(..., help="Nombre del perfil"),
-    set_active: bool = typer.Option(False, "--active/--no-active", help="Marcar como activo"),
+    name: str = typer.Argument(..., help="Profile name"),
+    set_active: bool = typer.Option(
+        False,
+        "--active/--no-active",
+        help="Mark the new profile as active",
+    ),
 ) -> None:
     """Add a new profile (interactive)."""
     _add_profile_interactive(name=name, set_active=set_active)
@@ -165,7 +169,9 @@ _VERSION_SQL = "SELECT CAST(VERSION() AS VARCHAR(200)) AS v"
 
 @app.command("test-connection")
 def test_connection_cmd(
-    profile: str | None = typer.Option(None, "--profile", "-p", help="Perfil a probar"),
+    profile: str | None = typer.Option(
+        None, "--profile", "-p", help="Profile to test (defaults to active profile)"
+    ),
 ) -> None:
     """Verify connectivity: open Netezza, run ``VERSION()``, report OK or FAIL (exit 0/1)."""
     locale = resolve_locale()

--- a/src/nz_mcp/i18n.py
+++ b/src/nz_mcp/i18n.py
@@ -5,6 +5,7 @@ Rule: every key MUST have both ``es`` and ``en``. ``test_i18n.py`` enforces pari
 
 from __future__ import annotations
 
+import locale as _std_locale
 import os
 from typing import Final, Literal, TypedDict
 
@@ -240,6 +241,12 @@ def resolve_locale(explicit: Locale | None = None) -> Locale:
             return "es"
         if value.startswith("en"):
             return "en"
+    try:
+        loc = _std_locale.getdefaultlocale()[0]
+        if loc and str(loc).lower().startswith("es"):
+            return "es"
+    except (OSError, ValueError, TypeError, AttributeError):
+        pass
     return DEFAULT_LOCALE
 
 

--- a/tests/unit/test_catalog_databases.py
+++ b/tests/unit/test_catalog_databases.py
@@ -6,7 +6,7 @@ from collections.abc import Sequence
 
 import pytest
 
-from nz_mcp.catalog.databases import list_databases
+from nz_mcp.catalog.databases import _row_to_database, list_databases
 from nz_mcp.config import Profile
 from nz_mcp.errors import NetezzaError
 
@@ -52,6 +52,11 @@ def _profile() -> Profile:
     )
 
 
+def test_row_to_database_accepts_tuple_or_list() -> None:
+    assert _row_to_database(("DEV", "ADMIN")) == {"name": "DEV", "owner": "ADMIN"}
+    assert _row_to_database(["DEV", "ADMIN"]) == {"name": "DEV", "owner": "ADMIN"}
+
+
 def test_list_databases_queries_catalog_with_optional_like(monkeypatch: pytest.MonkeyPatch) -> None:
     cursor = _FakeCursor(rows=[("DEV", "ADMIN"), ("DATA", "DBA")])
     connection = _FakeConnection(cursor)
@@ -69,8 +74,27 @@ def test_list_databases_queries_catalog_with_optional_like(monkeypatch: pytest.M
     out = list_databases(_profile(), pattern="D%")
 
     assert out == [{"name": "DEV", "owner": "ADMIN"}, {"name": "DATA", "owner": "DBA"}]
+
+
+def test_list_databases_accepts_list_rows_from_nzpy(monkeypatch: pytest.MonkeyPatch) -> None:
+    """nzpy may return ``tuple[list[Any], ...]`` from ``fetchall()`` — not tuple rows."""
+    cursor = _FakeCursor(rows=[["DEV", "ADMIN"], ["DATA", "DBA"]])
+    connection = _FakeConnection(cursor)
+
+    monkeypatch.setattr("nz_mcp.catalog.databases.get_password", lambda _name: "pw")
+    monkeypatch.setattr(
+        "nz_mcp.catalog.databases.open_connection",
+        lambda *_args, **_kwargs: connection,
+    )
+    monkeypatch.setattr(
+        "nz_mcp.catalog.databases.resolve_query",
+        lambda _query_id, _profile: "SELECT DATABASE, OWNER FROM _V_DATABASE",
+    )
+
+    out = list_databases(_profile(), pattern=None)
+    assert out == [{"name": "DEV", "owner": "ADMIN"}, {"name": "DATA", "owner": "DBA"}]
     assert cursor.executed_sql is not None and "_v_database" in cursor.executed_sql.lower()
-    assert cursor.executed_params == ("D%", "D%")
+    assert cursor.executed_params == (None, None)
     assert cursor.closed is True
     assert connection.closed is True
 

--- a/tests/unit/test_catalog_execute.py
+++ b/tests/unit/test_catalog_execute.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from itertools import chain, repeat
 from types import SimpleNamespace
-from typing import Any
+from typing import Any, cast
 
 import pytest
 from nzpy import ProgrammingError
@@ -314,7 +314,7 @@ def test_column_meta_maps_oid_int_to_name() -> None:
     class _C:
         description = (("c", 1043),)
 
-    meta = _column_meta_from_cursor(_C())
+    meta = _column_meta_from_cursor(cast(Any, _C()))
     assert meta == [{"name": "c", "type": "varchar"}]
 
 
@@ -322,14 +322,14 @@ def test_column_meta_empty_description() -> None:
     class _C:
         description = None
 
-    assert _column_meta_from_cursor(_C()) == []
+    assert _column_meta_from_cursor(cast(Any, _C())) == []
 
 
 def test_column_meta_non_sequence_and_single_part_descriptors() -> None:
     class _C:
         description = (123, ("only",))
 
-    meta = _column_meta_from_cursor(_C())
+    meta = _column_meta_from_cursor(cast(Any, _C()))
     assert meta == [{"name": "123", "type": "unknown"}, {"name": "only", "type": "unknown"}]
 
 
@@ -337,7 +337,7 @@ def test_column_meta_string_oid_and_unknown_int() -> None:
     class _C:
         description = (("a", "23"), ("b", 99999))
 
-    meta = _column_meta_from_cursor(_C())
+    meta = _column_meta_from_cursor(cast(Any, _C()))
     assert meta == [{"name": "a", "type": "integer"}, {"name": "b", "type": "99999"}]
 
 
@@ -345,7 +345,7 @@ def test_column_meta_null_type_cell() -> None:
     class _C:
         description = (("n", None),)
 
-    meta = _column_meta_from_cursor(_C())
+    meta = _column_meta_from_cursor(cast(Any, _C()))
     assert meta == [{"name": "n", "type": "unknown"}]
 
 

--- a/tests/unit/test_catalog_execute.py
+++ b/tests/unit/test_catalog_execute.py
@@ -7,10 +7,18 @@ from types import SimpleNamespace
 from typing import Any
 
 import pytest
+from nzpy import ProgrammingError
 
 from nz_mcp.catalog import execute as execute_mod
-from nz_mcp.catalog.execute import execute_select, fetch_explain_text, inject_limit
+from nz_mcp.catalog.execute import (
+    _column_meta_from_cursor,
+    _type_label_from_oid_cell,
+    execute_select,
+    fetch_explain_text,
+    inject_limit,
+)
 from nz_mcp.config import Profile
+from nz_mcp.errors import NetezzaError
 
 
 def test_inject_limit_adds_limit_when_missing() -> None:
@@ -77,7 +85,7 @@ def test_execute_select_streams_rows(monkeypatch: pytest.MonkeyPatch) -> None:
     out = execute_select(profile, "SELECT 1", max_rows=10, timeout_s=30)
     assert out["row_count"] == 3
     assert out["rows"] == [[1], [2], [3]]
-    assert out["columns"] == [{"name": "n", "type": "23"}]
+    assert out["columns"] == [{"name": "n", "type": "integer"}]
     assert out["truncated"] is False
     assert out["hint_key"] is None
 
@@ -261,3 +269,198 @@ def test_fetch_explain_text_concatenates_lines(monkeypatch: pytest.MonkeyPatch) 
 
     text = fetch_explain_text(profile, "EXPLAIN SELECT 1")
     assert "step1" in text and "step2" in text
+
+
+def test_fetch_explain_falls_back_to_cursor_notices(monkeypatch: pytest.MonkeyPatch) -> None:
+    profile = Profile(
+        name="dev",
+        host="h",
+        port=5480,
+        database="D",
+        user="u",
+        mode="read",
+    )
+
+    class _Cur:
+        notices: list[str]
+
+        def __init__(self) -> None:
+            self.notices = ["Seq Scan on t", "  Cost: 0"]
+
+        def execute(self, _sql: str) -> None:
+            return None
+
+        def fetchmany(self, _size: int) -> list[tuple[Any, ...]]:
+            raise ProgrammingError("no result set")
+
+        def close(self) -> None:
+            return None
+
+    class _Conn:
+        def cursor(self) -> _Cur:
+            return _Cur()
+
+        def close(self) -> None:
+            return None
+
+    monkeypatch.setattr(execute_mod, "get_password", lambda _n: "pw")
+    monkeypatch.setattr(execute_mod, "open_connection", lambda _p, _pw: _Conn())
+
+    text = fetch_explain_text(profile, "EXPLAIN SELECT 1")
+    assert "Seq Scan" in text
+
+
+def test_column_meta_maps_oid_int_to_name() -> None:
+    class _C:
+        description = (("c", 1043),)
+
+    meta = _column_meta_from_cursor(_C())
+    assert meta == [{"name": "c", "type": "varchar"}]
+
+
+def test_column_meta_empty_description() -> None:
+    class _C:
+        description = None
+
+    assert _column_meta_from_cursor(_C()) == []
+
+
+def test_column_meta_non_sequence_and_single_part_descriptors() -> None:
+    class _C:
+        description = (123, ("only",))
+
+    meta = _column_meta_from_cursor(_C())
+    assert meta == [{"name": "123", "type": "unknown"}, {"name": "only", "type": "unknown"}]
+
+
+def test_column_meta_string_oid_and_unknown_int() -> None:
+    class _C:
+        description = (("a", "23"), ("b", 99999))
+
+    meta = _column_meta_from_cursor(_C())
+    assert meta == [{"name": "a", "type": "integer"}, {"name": "b", "type": "99999"}]
+
+
+def test_column_meta_null_type_cell() -> None:
+    class _C:
+        description = (("n", None),)
+
+    meta = _column_meta_from_cursor(_C())
+    assert meta == [{"name": "n", "type": "unknown"}]
+
+
+def test_type_label_from_oid_cell_fallback() -> None:
+    assert _type_label_from_oid_cell("notdigits") == "notdigits"
+
+
+def test_execute_select_accepts_scalar_fetch_row(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Driver may yield a non-sequence cell row; normalize to a one-column list."""
+    profile = Profile(
+        name="dev",
+        host="h",
+        port=5480,
+        database="D",
+        user="u",
+        mode="read",
+    )
+
+    class _Cur:
+        description = (("x", 23),)
+        _done = False
+
+        def execute(self, _sql: str) -> None:
+            return None
+
+        def fetchmany(self, _size: int) -> list[Any]:
+            if self._done:
+                return []
+            self._done = True
+            return [42]
+
+        def close(self) -> None:
+            return None
+
+    class _Conn:
+        def cursor(self) -> _Cur:
+            return _Cur()
+
+        def close(self) -> None:
+            return None
+
+    monkeypatch.setattr(execute_mod, "get_password", lambda _n: "pw")
+    monkeypatch.setattr(execute_mod, "open_connection", lambda _p, _pw: _Conn())
+
+    out = execute_select(profile, "SELECT 1", max_rows=10, timeout_s=30)
+    assert out["rows"] == [[42]]
+
+
+def test_fetch_explain_empty_when_no_notices(monkeypatch: pytest.MonkeyPatch) -> None:
+    profile = Profile(
+        name="dev",
+        host="h",
+        port=5480,
+        database="D",
+        user="u",
+        mode="read",
+    )
+
+    class _Cur:
+        def __init__(self) -> None:
+            self.notices: list[str] = []
+
+        def execute(self, _sql: str) -> None:
+            return None
+
+        def fetchmany(self, _size: int) -> list[tuple[Any, ...]]:
+            raise ProgrammingError("no result set")
+
+        def close(self) -> None:
+            return None
+
+    class _Conn:
+        def cursor(self) -> _Cur:
+            return _Cur()
+
+        def close(self) -> None:
+            return None
+
+    monkeypatch.setattr(execute_mod, "get_password", lambda _n: "pw")
+    monkeypatch.setattr(execute_mod, "open_connection", lambda _p, _pw: _Conn())
+
+    assert fetch_explain_text(profile, "EXPLAIN SELECT 1") == ""
+
+
+def test_fetch_explain_wraps_unrelated_programming_error(monkeypatch: pytest.MonkeyPatch) -> None:
+    profile = Profile(
+        name="dev",
+        host="h",
+        port=5480,
+        database="D",
+        user="u",
+        mode="read",
+    )
+
+    class _Cur:
+        def execute(self, _sql: str) -> None:
+            return None
+
+        def fetchmany(self, _size: int) -> list[tuple[Any, ...]]:
+            raise ProgrammingError("permission denied for explain")
+
+        def close(self) -> None:
+            return None
+
+    class _Conn:
+        def cursor(self) -> _Cur:
+            return _Cur()
+
+        def close(self) -> None:
+            return None
+
+    monkeypatch.setattr(execute_mod, "get_password", lambda _n: "pw")
+    monkeypatch.setattr(execute_mod, "open_connection", lambda _p, _pw: _Conn())
+
+    with pytest.raises(NetezzaError) as exc:
+        fetch_explain_text(profile, "EXPLAIN SELECT 1")
+
+    assert exc.value.context.get("operation") == "explain"

--- a/tests/unit/test_catalog_row_shape.py
+++ b/tests/unit/test_catalog_row_shape.py
@@ -1,0 +1,16 @@
+"""Tests for ``catalog.row_shape`` helpers."""
+
+from __future__ import annotations
+
+from nz_mcp.catalog.row_shape import is_sequence_row
+
+
+def test_is_sequence_row_tuple_and_list() -> None:
+    assert is_sequence_row(("a", "b"), 2) is True
+    assert is_sequence_row(["a", "b"], 2) is True
+
+
+def test_is_sequence_row_rejects_short_or_non_sequence() -> None:
+    assert is_sequence_row(("a",), 2) is False
+    assert is_sequence_row(None, 2) is False
+    assert is_sequence_row("ab", 2) is False

--- a/tests/unit/test_i18n.py
+++ b/tests/unit/test_i18n.py
@@ -27,10 +27,37 @@ def test_resolve_locale_from_env(monkeypatch: pytest.MonkeyPatch) -> None:
     assert resolve_locale() == "es"
 
 
+def test_resolve_locale_lang_en(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("NZ_MCP_LANG", raising=False)
+    monkeypatch.setenv("LANG", "en_GB.UTF-8")
+    monkeypatch.setattr("nz_mcp.i18n._std_locale.getdefaultlocale", lambda: (None, None))
+    assert resolve_locale() == "en"
+
+
 def test_resolve_locale_default_when_unknown(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.delenv("NZ_MCP_LANG", raising=False)
     monkeypatch.setenv("LANG", "fr_FR.UTF-8")
+    monkeypatch.setattr("nz_mcp.i18n._std_locale.getdefaultlocale", lambda: (None, None))
     assert resolve_locale() == i18n.DEFAULT_LOCALE
+
+
+def test_resolve_locale_getdefaultlocale_errors_fall_back(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("NZ_MCP_LANG", raising=False)
+    monkeypatch.delenv("LANG", raising=False)
+
+    def _boom() -> tuple[str | None, str | None]:
+        raise OSError("locale")
+
+    monkeypatch.setattr("nz_mcp.i18n._std_locale.getdefaultlocale", _boom)
+    assert resolve_locale() == i18n.DEFAULT_LOCALE
+
+
+def test_resolve_locale_from_getdefaultlocale_es(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Windows often lacks ``LANG``; ``locale.getdefaultlocale()`` can still be ``es_*``."""
+    monkeypatch.delenv("NZ_MCP_LANG", raising=False)
+    monkeypatch.delenv("LANG", raising=False)
+    monkeypatch.setattr("nz_mcp.i18n._std_locale.getdefaultlocale", lambda: ("es_ES", "utf-8"))
+    assert resolve_locale() == "es"
 
 
 def test_t_formats_placeholders() -> None:


### PR DESCRIPTION
## ¿Qué cambia?
Endurecimiento v0.1 (#69): filas `list`/`tuple` en catálogo, `typer>=0.15`, `EXPLAIN` vía notices cuando no hay result set, OIDs en metadatos de columnas, `resolve_locale` en Windows, y `help` en inglés en CLI tocada.

## Issue relacionado
Closes #69

## Acción según AGENTS.md
- **Ruta (keywords)**: catalog, execute, i18n, CLI, deps
- **Docs leídos**:
  - `docs/standards/git-workflow.md`
  - `AGENTS.md`
- **Rol asumido**: Backend Developer

## Auditoría pre-merge
Checklist según template: contrato, seguridad (sin SQL nuevo sin guard en este PR focal), tests y cobertura ≥85%, ruff/mypy limpios, CHANGELOG bilingüe en Unreleased.

## Validación humana
- [ ] No — cambios mecánicos y tests automatizados; integración Netezza sigue opcional con `NZ_MCP_RUN_INTEGRATION`.
