### PR TITLE
fix(server): inlinear refs de JSON Schema en tools MCP (#73)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ Cada entrada se documenta en **español** y **english**.
 ## [Unreleased]
 
 ### Fixed
+- ES: ``list_tools`` / ``outputSchema`` — los ``$ref`` a ``#/$defs/...`` se inlinean antes de envolver ``result``, para que clientes MCP (p. ej. Claude Desktop) no fallen con ``PointerToNowhere``.
+- EN: ``list_tools`` / ``outputSchema`` — ``$ref`` targets under ``#/$defs/...`` are inlined before wrapping ``result``, so MCP clients (e.g. Claude Desktop) do not hit ``PointerToNowhere``.
 - ES: el catálogo acepta filas devueltas como ``list`` (nzpy) además de ``tuple``; helper compartido ``is_sequence_row`` en consultas a ``_v_*``.
 - EN: catalog parsing accepts nzpy ``list`` rows as well as ``tuple`` rows; shared ``is_sequence_row`` helper for ``_v_*`` queries.
 - ES: dependencia ``typer>=0.15`` para compatibilidad con **click 8.2** (CLI sin errores de import).

--- a/src/nz_mcp/server.py
+++ b/src/nz_mcp/server.py
@@ -3,9 +3,10 @@
 from __future__ import annotations
 
 import inspect
+from copy import deepcopy
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Any
+from typing import Any, cast
 
 import anyio
 from mcp import types
@@ -152,18 +153,60 @@ def _to_mcp_tool(listing: ToolListing) -> types.Tool:
     return types.Tool(
         name=listing.name,
         description=listing.description,
-        inputSchema=listing.input_schema,
+        inputSchema=_inline_refs(listing.input_schema),
         outputSchema=_tool_output_schema(listing.output_schema),
         annotations=types.ToolAnnotations.model_validate(listing.annotations),
     )
 
 
+def _inline_refs(schema: dict[str, Any]) -> dict[str, Any]:
+    """Inline ``$ref`` to ``#/$defs`` / ``#/definitions`` so nested MCP schemas stay valid.
+
+    Pydantic puts reusable models under ``$defs`` with ``$ref`` at ``#/$defs/Name``. Wrapping the
+    result model under ``properties.result`` breaks root-based resolvers (e.g. Claude Desktop).
+    Inlining yields a self-contained subtree.
+    """
+    defs: dict[str, Any] = {}
+    defs.update(schema.get("$defs") or {})
+    defs.update(schema.get("definitions") or {})
+
+    out = deepcopy(schema)
+    out.pop("$defs", None)
+    out.pop("definitions", None)
+
+    if not defs:
+        return out
+
+    def _walk(node: Any, visited: frozenset[str]) -> Any:
+        if isinstance(node, dict):
+            ref = node.get("$ref")
+            if isinstance(ref, str) and ref.startswith(("#/$defs/", "#/definitions/")):
+                name = ref.rsplit("/", 1)[-1]
+                if name in visited:
+                    return dict(node)
+                target = defs.get(name)
+                if target is None:
+                    return {k: _walk(v, visited) for k, v in node.items()}
+                merged: dict[str, Any] = deepcopy(target)
+                for k, v in node.items():
+                    if k != "$ref":
+                        merged[k] = v
+                return _walk(merged, visited | {name})
+            return {k: _walk(v, visited) for k, v in node.items()}
+        if isinstance(node, list):
+            return [_walk(x, visited) for x in node]
+        return node
+
+    return cast(dict[str, Any], _walk(out, frozenset()))
+
+
 def _tool_output_schema(result_schema: dict[str, Any]) -> dict[str, Any]:
+    inlined = _inline_refs(result_schema)
     return {
         "type": "object",
         "additionalProperties": False,
         "properties": {
-            "result": result_schema,
+            "result": inlined,
             "error": {
                 "type": "object",
                 "additionalProperties": True,

--- a/tests/unit/test_server_json_schema.py
+++ b/tests/unit/test_server_json_schema.py
@@ -1,0 +1,151 @@
+"""Unit tests for JSON Schema inlining in MCP tool adapters (issue #73)."""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+import pytest
+from mcp import types
+
+from nz_mcp.server import _inline_refs, _to_mcp_tool, list_tools
+from nz_mcp.tools.registry import TOOLS
+
+
+def _assert_no_defs_refs(obj: Any) -> None:
+    """Fail if any internal JSON Schema ref to ``#/$defs/...`` remains."""
+    if isinstance(obj, dict):
+        ref = obj.get("$ref")
+        if isinstance(ref, str) and ref.startswith("#/$defs/"):
+            pytest.fail(f"Unresolved internal $ref: {ref}")
+        assert "$defs" not in obj
+        for v in obj.values():
+            _assert_no_defs_refs(v)
+    elif isinstance(obj, list):
+        for x in obj:
+            _assert_no_defs_refs(x)
+
+
+def test_inline_refs_simple() -> None:
+    schema: dict[str, Any] = {
+        "type": "object",
+        "$defs": {
+            "Widget": {
+                "type": "object",
+                "properties": {"id": {"type": "integer"}},
+                "required": ["id"],
+            }
+        },
+        "properties": {
+            "item": {"$ref": "#/$defs/Widget"},
+        },
+    }
+    out = _inline_refs(schema)
+    assert "$defs" not in out
+    assert out["properties"]["item"]["type"] == "object"
+    assert out["properties"]["item"]["properties"]["id"]["type"] == "integer"
+
+
+def test_inline_refs_nested() -> None:
+    schema: dict[str, Any] = {
+        "type": "object",
+        "$defs": {
+            "Inner": {"type": "boolean"},
+            "Outer": {
+                "type": "object",
+                "properties": {"inner": {"$ref": "#/$defs/Inner"}},
+            },
+        },
+        "properties": {"o": {"$ref": "#/$defs/Outer"}},
+    }
+    out = _inline_refs(schema)
+    assert "$defs" not in out
+    assert out["properties"]["o"]["properties"]["inner"]["type"] == "boolean"
+
+
+def test_inline_refs_no_defs() -> None:
+    schema: dict[str, Any] = {
+        "type": "object",
+        "properties": {"n": {"type": "integer"}},
+    }
+    out = _inline_refs(schema)
+    assert out == schema
+
+
+def test_inline_refs_preserves_siblings() -> None:
+    schema: dict[str, Any] = {
+        "type": "object",
+        "$defs": {"X": {"type": "string", "title": "orig"}},
+        "properties": {
+            "a": {"$ref": "#/$defs/X", "description": "overridden"},
+        },
+    }
+    out = _inline_refs(schema)
+    assert out["properties"]["a"]["description"] == "overridden"
+    assert out["properties"]["a"]["type"] == "string"
+
+
+def test_inline_refs_definitions_alias() -> None:
+    schema: dict[str, Any] = {
+        "type": "object",
+        "definitions": {"Legacy": {"type": "string"}},
+        "properties": {"z": {"$ref": "#/definitions/Legacy"}},
+    }
+    out = _inline_refs(schema)
+    assert "definitions" not in out
+    assert out["properties"]["z"]["type"] == "string"
+
+
+def test_inline_refs_cycle_keeps_ref() -> None:
+    schema: dict[str, Any] = {
+        "type": "object",
+        "$defs": {
+            "Node": {
+                "type": "object",
+                "properties": {"next": {"$ref": "#/$defs/Node"}},
+            }
+        },
+        "properties": {"root": {"$ref": "#/$defs/Node"}},
+    }
+    out = _inline_refs(schema)
+    assert "$defs" not in out
+    n = out["properties"]["root"]["properties"]["next"]
+    assert n.get("$ref") == "#/$defs/Node"
+
+
+def test_inline_refs_unresolved_ref_walks_other_keys() -> None:
+    schema: dict[str, Any] = {
+        "type": "object",
+        "$defs": {"Other": {"type": "string"}},
+        "properties": {
+            "bad": {"$ref": "#/$defs/Missing", "x": 1},
+        },
+    }
+    out = _inline_refs(schema)
+    assert out["properties"]["bad"]["$ref"] == "#/$defs/Missing"
+    assert out["properties"]["bad"]["x"] == 1
+
+
+def test_to_mcp_tool_output_schema_no_refs_for_list_databases() -> None:
+    listings = {x.name: x for x in list_tools()}
+    listing = listings["nz_list_databases"]
+    tool = _to_mcp_tool(listing)
+    assert tool.outputSchema is not None
+    result = tool.outputSchema["properties"]["result"]
+    _assert_no_defs_refs(result)
+    assert "#/$defs/" not in json.dumps(tool.outputSchema)
+
+
+@pytest.mark.contract
+def test_mcp_tool_model_validate_list_tools() -> None:
+    """MCP SDK must accept every tool schema we emit (no PointerToNowhere)."""
+    for listing in list_tools():
+        tool = _to_mcp_tool(listing)
+        types.Tool.model_validate(tool.model_dump())
+
+
+def test_all_tool_output_schemas_inline_internal_refs() -> None:
+    for spec in TOOLS.values():
+        raw = spec.output_model.model_json_schema()
+        inlined = _inline_refs(raw)
+        assert "#/$defs/" not in json.dumps(inlined)


### PR DESCRIPTION
## ¿Qué cambia?

Se corrige el error `PointerToNowhere` en Claude Desktop: los `outputSchema` (y `inputSchema`) de las tools MCP envolvían el JSON Schema de Pydantic con `$defs` en un subárbol donde los `$ref: "#/$defs/..."` apuntaban al documento equivocado. Ahora se inlinean esas definiciones antes de envolver `result`.

## Issue relacionado

Closes #73

## Acción según AGENTS.md

- **Ruta (keywords)**: MCP server, JSON Schema, `list_tools`, Claude Desktop
- **Docs leídos**:
  - `docs/standards/git-workflow.md`
  - `docs/standards/pr-audit.md`
- **Rol asumido**: Backend Developer

## Archivos esperados (según el issue)

- `src/nz_mcp/server.py` — helper `_inline_refs`, uso en `_to_mcp_tool` y `_tool_output_schema`
- Tests unitarios y contrato para schemas sin `$ref` rotos
- `CHANGELOG.md` — entrada bilingüe Unreleased

## Auditoría pre-merge — 7 dimensiones

> Marca todas las casillas. Bloqueantes sin marcar = no merge.

### 1. Contrato y compatibilidad

- [x] Si toca tools: `docs/architecture/tools-contract.md` actualizado en este PR. (no aplica — mismo contrato de respuesta; solo forma del schema)
- [x] Si hay cambio observable: `CHANGELOG.md` con entrada bilingüe en `Unreleased`.
- [x] Sin breaking change inesperado.

### 2. Seguridad

- [x] Todo SQL pasa por `sql_guard.validate()`. (no tocado)
- [x] Sin SQL concatenado (parametrizado).
- [x] Sin credenciales en código, logs, tests, fixtures, comentarios.
- [x] Si toca `sql_guard.py` o `auth.py`: cobertura sigue en 100 %. (no tocado)
- [x] Si toca `sql_guard.py`: ≥ 3 tests adversariales nuevos. (no tocado)

### 3. Mantenibilidad y diseño

- [x] Toqué solo los archivos esperados (o documenté por qué no).
- [x] Sin abstracciones nuevas sin 3 usos reales.
- [x] Sin dependencias nuevas sin ADR.
- [x] Funciones < 50 LoC, args < 4.
- [x] Una intención por PR.
- [x] PR < 400 LoC sin tests/docs (o justificado).

### 4. Tests

- [x] Tests para todo comportamiento nuevo.
- [x] `pytest -m "not integration"` verde local.
- [x] Cobertura ≥ 85 % global, no cae respecto a `main`.
- [x] Sin `pytest.skip()` ni `xfail` sin issue.

### 5. Tipado y estilo

- [x] `ruff check .` y `ruff format --check .` limpios.
- [x] `mypy --strict` limpio en módulos tocados.
- [x] Sin `Any` en superficies públicas sin justificación.
- [x] Sin `except Exception:` sin re-raise tipado.

### 6. Documentación

- [x] Si cambia API pública: `tools-contract.md` actualizado. (no aplica)
- [x] Si cambia comportamiento: `CHANGELOG.md` actualizado (ES + EN).
- [x] Si introduce decisión arquitectónica: nuevo ADR en `docs/adr/`. (no)
- [x] Mensajes nuevos: claves añadidas en ES **y** EN. (no hay mensajes i18n nuevos)

### 7. Idioma y forma

- [x] Título de PR en español, formato conventional commit.
- [x] Branch cumple regex (validado por CI).
- [x] Commits en español, conventional (validados por CI).
- [x] Código y comentarios en inglés.

## Validación humana requerida

- [ ] Sí — explicar por qué:
- [x] No — cambio mecánico en serialización de schemas; validado con tests y `types.Tool.model_validate`.

## Notas para el auditor

Opción A del issue (inlinear refs). Guarda de ciclos en refs recursivas; refs no resueltas se dejan y se recorren hermanos.
