### PR TITLE
fix: create_table y sql_guard NZPLSQL (issue 79)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,10 @@ Cada entrada se documenta en **español** y **english**.
 - EN: CLI command ``nz-mcp edit-profile`` to update mode/limits on an existing profile (``tomli-w`` dependency).
 
 ### Fixed
+- ES: ``nz_create_table`` / ``execute_create_table`` — columna con ``default`` omitido o ``null`` en JSON ya no falla; se omite la cláusula ``DEFAULT`` (equivalente a sin default). Rechazo explícito de ``default`` string con ``;`` (inyección).
+- EN: ``nz_create_table`` / ``execute_create_table`` — column with omitted or JSON ``null`` ``default`` no longer errors; the ``DEFAULT`` clause is omitted (same as no default). String defaults containing ``;`` are rejected (injection).
+- ES: ``sql_guard`` — ``CREATE PROCEDURE ... LANGUAGE NZPLSQL AS`` se valida por cabecera (modo ``admin``); el cuerpo NZPLSQL no se parsea con ``sqlglot``, desbloqueando ``nz_clone_procedure`` con DDL real.
+- EN: ``sql_guard`` — ``CREATE PROCEDURE ... LANGUAGE NZPLSQL AS`` is header-validated (``admin`` mode); the NZPLSQL body is not parsed with ``sqlglot``, unblocking ``nz_clone_procedure`` with real DDL.
 - ES: ``list_tools`` / ``outputSchema`` — los ``$ref`` a ``#/$defs/...`` se inlinean antes de envolver ``result``, para que clientes MCP (p. ej. Claude Desktop) no fallen con ``PointerToNowhere``.
 - EN: ``list_tools`` / ``outputSchema`` — ``$ref`` targets under ``#/$defs/...`` are inlined before wrapping ``result``, so MCP clients (e.g. Claude Desktop) do not hit ``PointerToNowhere``.
 - ES: el catálogo acepta filas devueltas como ``list`` (nzpy) además de ``tuple``; helper compartido ``is_sequence_row`` en consultas a ``_v_*``.

--- a/docs/architecture/security-model.md
+++ b/docs/architecture/security-model.md
@@ -55,6 +55,10 @@
 - Retorna un `ParsedStatement` tipado: `{ kind: Enum, tables: list, has_where: bool, raw: str }`.
 - Lanza `GuardRejectedError` con `code` y `hint` i18n.
 
+#### Procedimientos `CREATE ... LANGUAGE NZPLSQL AS`
+
+`sqlglot` no clasifica cuerpos NZPLSQL reales (`DECLARE`, `BEGIN`/`END`, cursores, etc.). Para sentencias que contienen el marcador `LANGUAGE NZPLSQL AS`, el guard **no** intenta parsear el cuerpo: valida la cabecera con regex (firma `schema.procedimiento`, sin `;` en la cabecera) y los identificadores con las mismas reglas que el catálogo. El cuerpo se trata como **opaco**; no es texto libre arbitrario del LLM en los flujos soportados (p. ej. clonado desde DDL ya obtenido del catálogo del propio servidor). El riesgo de inyección se concentra en la cabecera; ahí se exige `admin` y se rechazan cabeceras malformadas o apiladas.
+
 ### Reglas por modo
 
 | Statement kind | `read` | `write` | `admin` |

--- a/src/nz_mcp/catalog/ddl.py
+++ b/src/nz_mcp/catalog/ddl.py
@@ -63,13 +63,13 @@ def _validate_column_type_fragment(raw: str) -> str:
 
 
 def _format_default(value: Any) -> str:
-    if value is None:
-        raise InvalidInputError(detail="Column default cannot be null; omit the key instead.")
     if isinstance(value, bool):
         return "TRUE" if value else "FALSE"
     if isinstance(value, int | float) and not isinstance(value, bool):
         return str(value)
     if isinstance(value, str):
+        if ";" in value:
+            raise InvalidInputError(detail="Column default string cannot contain semicolons.")
         return "'" + value.replace("'", "''") + "'"
     raise InvalidInputError(detail="Column default must be a string, number, or boolean.")
 
@@ -121,7 +121,7 @@ def _build_create_table_base_sql(
         segment = f"{cname} {ctype}"
         if not bool(col.get("nullable", True)):
             segment += " NOT NULL"
-        if "default" in col:
+        if col.get("default") is not None:
             segment += f" DEFAULT {_format_default(col.get('default'))}"
         lines.append(segment)
     inner = ",\n  ".join(lines)

--- a/src/nz_mcp/sql_guard.py
+++ b/src/nz_mcp/sql_guard.py
@@ -6,6 +6,7 @@ See docs/architecture/security-model.md for the full matrix.
 
 from __future__ import annotations
 
+import re
 from dataclasses import dataclass
 from enum import StrEnum
 from typing import Final
@@ -13,8 +14,9 @@ from typing import Final
 import sqlglot
 from sqlglot import expressions as exp
 
+from nz_mcp.catalog.identifier import validate_catalog_identifier
 from nz_mcp.config import PermissionMode
-from nz_mcp.errors import GuardRejectedError
+from nz_mcp.errors import GuardRejectedError, InvalidInputError, PermissionDeniedError
 
 
 class StatementKind(StrEnum):
@@ -43,6 +45,18 @@ _DDL_KINDS: Final[frozenset[StatementKind]] = frozenset(
     {StatementKind.CREATE, StatementKind.TRUNCATE, StatementKind.DROP}
 )
 
+_NZPLSQL_MARKER: Final[re.Pattern[str]] = re.compile(
+    r"\bLANGUAGE\s+NZPLSQL\s+AS\b",
+    re.IGNORECASE,
+)
+_NZPLSQL_PROC_HEAD: Final[re.Pattern[str]] = re.compile(
+    r"^\s*CREATE\s+(?:OR\s+REPLACE\s+)?PROCEDURE\s+"
+    r"(?P<sch>[A-Za-z][A-Za-z0-9_]*)\s*\.\s*(?P<proc>[A-Za-z][A-Za-z0-9_]*)"
+    r"\s*\([^)]*\)"
+    r"(?:\s+RETURNS\b[\s\S]*)?\s*$",
+    re.IGNORECASE | re.DOTALL,
+)
+
 
 @dataclass(frozen=True, slots=True)
 class ParsedStatement:
@@ -58,6 +72,9 @@ def validate(sql: str, *, mode: PermissionMode) -> ParsedStatement:
     """
     if not sql or not sql.strip():
         raise GuardRejectedError(code="EMPTY_STATEMENT")
+
+    if _NZPLSQL_MARKER.search(sql):
+        return _validate_nzplsql_procedure(sql, mode=mode)
 
     try:
         parsed_list = sqlglot.parse(sql, read="postgres")
@@ -90,6 +107,44 @@ def validate(sql: str, *, mode: PermissionMode) -> ParsedStatement:
     _enforce(kind=kind, has_where=has_where, mode=mode)
 
     return ParsedStatement(kind=kind, has_where=has_where, raw=sql)
+
+
+def _validate_nzplsql_procedure(sql: str, *, mode: PermissionMode) -> ParsedStatement:
+    """Validate ``CREATE ... PROCEDURE ... LANGUAGE NZPLSQL AS`` without parsing the body.
+
+    ``sqlglot`` cannot classify NZPLSQL procedure bodies; the header is validated with
+    regex and catalog identifier rules. The body is treated as opaque (trusted when
+    sourced from server catalog DDL, e.g. clone).
+    """
+    if mode != "admin":
+        raise PermissionDeniedError(required="admin", actual=mode)
+
+    parts = _NZPLSQL_MARKER.split(sql, maxsplit=1)
+    expected_segments = 2
+    if len(parts) != expected_segments or not parts[1].strip():
+        raise GuardRejectedError(
+            code="UNKNOWN_STATEMENT",
+            detail="Malformed NZPLSQL procedure (missing body after LANGUAGE NZPLSQL AS).",
+        )
+
+    head = parts[0].strip()
+    if ";" in head:
+        raise GuardRejectedError(code="STACKED_NOT_ALLOWED", count=2)
+
+    m = _NZPLSQL_PROC_HEAD.fullmatch(head)
+    if not m:
+        raise GuardRejectedError(code="UNKNOWN_STATEMENT", detail="Malformed procedure header.")
+
+    try:
+        validate_catalog_identifier(m.group("sch"))
+        validate_catalog_identifier(m.group("proc"))
+    except InvalidInputError as exc:
+        raise GuardRejectedError(
+            code="UNKNOWN_STATEMENT",
+            detail="Invalid procedure identifier.",
+        ) from exc
+
+    return ParsedStatement(kind=StatementKind.CREATE, has_where=False, raw=sql)
 
 
 _SIMPLE_KIND_MAP: Final[tuple[tuple[type[exp.Expr], StatementKind], ...]] = (

--- a/tests/unit/test_catalog_clone.py
+++ b/tests/unit/test_catalog_clone.py
@@ -31,6 +31,43 @@ _SAMPLE_DDL = (
     "END_PROC\n"
 )
 
+_REAL_NZPLSQL_BODY_DDL = (
+    "CREATE OR REPLACE PROCEDURE DBO.TGT(DATE)\n"
+    "RETURNS INTEGER\n"
+    "LANGUAGE NZPLSQL AS\n"
+    "DECLARE\n"
+    "  v_campo VARCHAR(10000);\n"
+    "BEGIN\n"
+    "  RETURN 0;\n"
+    "END;\n"
+)
+
+
+def test_clone_dry_run_real_shaped_nzplsql_body(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(
+        "nz_mcp.catalog.clone.get_procedure_ddl",
+        lambda *_a, **_k: _REAL_NZPLSQL_BODY_DDL,
+    )
+    monkeypatch.setattr("nz_mcp.catalog.clone.list_procedures", lambda *_a, **_k: [])
+
+    out = clone_procedure(
+        _profile(),
+        source_database="DEV",
+        source_schema="DBO",
+        source_procedure="TGT",
+        source_signature=None,
+        target_database="DEV",
+        target_schema="DBO",
+        target_procedure="TGT_CLONE",
+        replace_if_exists=False,
+        transformations=None,
+        dry_run=True,
+        confirm=False,
+    )
+    assert out["dry_run"] is True
+    assert "VARCHAR(10000)" in out["ddl_to_execute"]
+    assert "DECLARE" in out["ddl_to_execute"]
+
 
 def test_clone_dry_run_returns_ddl_and_warnings(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(

--- a/tests/unit/test_catalog_ddl.py
+++ b/tests/unit/test_catalog_ddl.py
@@ -196,6 +196,85 @@ def test_invalid_default_type_rejected(monkeypatch: pytest.MonkeyPatch) -> None:
         )
 
 
+def test_create_table_column_without_default(monkeypatch: pytest.MonkeyPatch) -> None:
+    fake = _FakeConn()
+    monkeypatch.setattr("nz_mcp.catalog.ddl.open_connection", lambda _p, _w: fake)
+    monkeypatch.setattr("nz_mcp.catalog.ddl.get_password", lambda _n: "pw")
+    prof = _admin_profile()
+    out = execute_create_table(
+        prof,
+        database="DEV",
+        schema="PUBLIC",
+        table="TND",
+        columns=[{"name": "ID", "type": "INT"}, {"name": "N", "type": "VARCHAR(100)"}],
+        distribution=None,
+        organized_on=None,
+        if_not_exists=True,
+    )
+    sql = str(out["ddl_executed"])
+    inner = sql.split("(", 1)[1].rsplit(")", 1)[0]
+    assert "DEFAULT" not in inner
+
+
+def test_create_table_column_explicit_null_default(monkeypatch: pytest.MonkeyPatch) -> None:
+    fake = _FakeConn()
+    monkeypatch.setattr("nz_mcp.catalog.ddl.open_connection", lambda _p, _w: fake)
+    monkeypatch.setattr("nz_mcp.catalog.ddl.get_password", lambda _n: "pw")
+    prof = _admin_profile()
+    out = execute_create_table(
+        prof,
+        database="DEV",
+        schema="PUBLIC",
+        table="TNULL",
+        columns=[
+            {"name": "ID", "type": "INT"},
+            {"name": "N", "type": "VARCHAR(100)", "default": None},
+        ],
+        distribution=None,
+        organized_on=None,
+        if_not_exists=True,
+    )
+    sql = str(out["ddl_executed"])
+    inner = sql.split("(", 1)[1].rsplit(")", 1)[0]
+    assert "DEFAULT" not in inner
+
+
+def test_create_table_column_with_default_literal(monkeypatch: pytest.MonkeyPatch) -> None:
+    fake = _FakeConn()
+    monkeypatch.setattr("nz_mcp.catalog.ddl.open_connection", lambda _p, _w: fake)
+    monkeypatch.setattr("nz_mcp.catalog.ddl.get_password", lambda _n: "pw")
+    prof = _admin_profile()
+    out = execute_create_table(
+        prof,
+        database="DEV",
+        schema="PUBLIC",
+        table="TDEF",
+        columns=[{"name": "N", "type": "INT", "default": 0}],
+        distribution=None,
+        organized_on=None,
+        if_not_exists=True,
+    )
+    assert "DEFAULT 0" in str(out["ddl_executed"])
+
+
+def test_create_table_column_with_injection_in_default(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr("nz_mcp.catalog.ddl.open_connection", lambda _p, _w: _FakeConn())
+    monkeypatch.setattr("nz_mcp.catalog.ddl.get_password", lambda _n: "pw")
+    prof = _admin_profile()
+    with pytest.raises(InvalidInputError) as ei:
+        execute_create_table(
+            prof,
+            database="DEV",
+            schema="PUBLIC",
+            table="T",
+            columns=[{"name": "ID", "type": "INTEGER", "default": "0; DROP TABLE x"}],
+            distribution=None,
+            organized_on=None,
+            if_not_exists=True,
+        )
+    assert "semicolon" in str(ei.value).lower()
+
+
 def test_distribution_hash_requires_columns(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr("nz_mcp.catalog.ddl.open_connection", lambda _p, _w: _FakeConn())
     monkeypatch.setattr("nz_mcp.catalog.ddl.get_password", lambda _n: "pw")

--- a/tests/unit/test_sql_guard.py
+++ b/tests/unit/test_sql_guard.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import pytest
 
-from nz_mcp.errors import GuardRejectedError
+from nz_mcp.errors import GuardRejectedError, PermissionDeniedError
 from nz_mcp.sql_guard import StatementKind, validate
 
 
@@ -77,3 +77,94 @@ def test_whitespace_only_rejected() -> None:
     with pytest.raises(GuardRejectedError) as exc:
         validate("   \n\t  ", mode="read")
     assert exc.value.code == "EMPTY_STATEMENT"
+
+
+def test_validate_trivial_nzplsql_procedure() -> None:
+    sql = "CREATE OR REPLACE PROCEDURE DBO.TGT()\nLANGUAGE NZPLSQL AS\nBEGIN\n  NULL;\nEND;\n"
+    parsed = validate(sql, mode="admin")
+    assert parsed.kind is StatementKind.CREATE
+    assert parsed.raw == sql
+
+
+def test_validate_procedure_with_declarations() -> None:
+    sql = """CREATE OR REPLACE PROCEDURE DBO.TGT(DATE)
+RETURNS INTEGER
+LANGUAGE NZPLSQL AS
+DECLARE
+  v_campo VARCHAR(10000);
+BEGIN
+  RETURN 0;
+END;
+"""
+    parsed = validate(sql, mode="admin")
+    assert parsed.kind is StatementKind.CREATE
+
+
+def test_validate_procedure_with_loops() -> None:
+    sql = """CREATE OR REPLACE PROCEDURE SCH.P()
+RETURNS INTEGER
+LANGUAGE NZPLSQL AS
+BEGIN
+  FOR r IN SELECT 1 AS x FROM DUAL LOOP
+    EXIT;
+  END LOOP;
+  RETURN 0;
+END;
+"""
+    parsed = validate(sql, mode="admin")
+    assert parsed.kind is StatementKind.CREATE
+
+
+def test_validate_procedure_with_exception() -> None:
+    sql = """CREATE OR REPLACE PROCEDURE SCH.P()
+RETURNS INTEGER
+LANGUAGE NZPLSQL AS
+BEGIN
+  NULL;
+EXCEPTION WHEN OTHERS THEN
+  NULL;
+END;
+"""
+    parsed = validate(sql, mode="admin")
+    assert parsed.kind is StatementKind.CREATE
+
+
+def test_validate_procedure_requires_admin_mode() -> None:
+    sql = "CREATE PROCEDURE A.B()\nLANGUAGE NZPLSQL AS\nBEGIN NULL; END;\n"
+    with pytest.raises(PermissionDeniedError):
+        validate(sql, mode="write")
+
+
+def test_validate_malformed_nzplsql_missing_body() -> None:
+    sql = "CREATE PROCEDURE A.B()\nLANGUAGE NZPLSQL AS\n"
+    with pytest.raises(GuardRejectedError) as exc:
+        validate(sql, mode="admin")
+    assert exc.value.code == "UNKNOWN_STATEMENT"
+
+
+def test_validate_nzplsql_procedure_rejects_overlong_catalog_identifier() -> None:
+    long_schema = "S" * 130
+    sql = f"CREATE PROCEDURE {long_schema}.P()\nLANGUAGE NZPLSQL AS\nBEGIN NULL; END;\n"
+    with pytest.raises(GuardRejectedError) as exc:
+        validate(sql, mode="admin")
+    assert exc.value.code == "UNKNOWN_STATEMENT"
+    assert "identifier" in str(exc.value).lower()
+
+
+def test_validate_malformed_procedure_header_unqualified() -> None:
+    sql = "CREATE PROCEDURE UNQUALIFIED()\nLANGUAGE NZPLSQL AS\nBEGIN NULL; END;\n"
+    with pytest.raises(GuardRejectedError) as exc:
+        validate(sql, mode="admin")
+    assert exc.value.code == "UNKNOWN_STATEMENT"
+
+
+def test_validate_non_procedure_statements_still_parsed() -> None:
+    assert validate("INSERT INTO t (a) VALUES (1)", mode="write").kind is StatementKind.INSERT
+    assert validate("CREATE TABLE x (id INT)", mode="admin").kind is StatementKind.CREATE
+
+
+def test_validate_create_table_without_language_nzplsql_not_header_only_path() -> None:
+    """Statements without ``LANGUAGE NZPLSQL AS`` stay on the sqlglot path."""
+    sql = "CREATE TABLE z (a INT)"
+    assert "LANGUAGE" not in sql
+    assert validate(sql, mode="admin").kind is StatementKind.CREATE

--- a/tests/unit/test_sql_guard_adversarial.py
+++ b/tests/unit/test_sql_guard_adversarial.py
@@ -81,3 +81,19 @@ def test_show_stacked_with_select_blocked() -> None:
     with pytest.raises(GuardRejectedError) as exc:
         validate("SHOW DATABASES; SELECT 1", mode="read")
     assert exc.value.code == "STACKED_NOT_ALLOWED"
+
+
+@pytest.mark.adversarial
+def test_nzplsql_procedure_header_stacked_blocked() -> None:
+    sql = "CREATE PROCEDURE A.B(); DROP TABLE t; LANGUAGE NZPLSQL AS\nBEGIN NULL; END;\n"
+    with pytest.raises(GuardRejectedError) as exc:
+        validate(sql, mode="admin")
+    assert exc.value.code == "STACKED_NOT_ALLOWED"
+
+
+@pytest.mark.adversarial
+def test_nzplsql_procedure_invalid_identifier_blocked() -> None:
+    sql = "CREATE PROCEDURE 1A.B()\nLANGUAGE NZPLSQL AS\nBEGIN NULL; END;\n"
+    with pytest.raises(GuardRejectedError) as exc:
+        validate(sql, mode="admin")
+    assert exc.value.code == "UNKNOWN_STATEMENT"


### PR DESCRIPTION
## ¿Qué cambia?
Corrige dos regresiones P0 del issue #79: `nz_create_table` rechazaba `default` nulo/omitido y `sql_guard` no podía clasificar DDL de procedimientos NZPLSQL con cuerpo real, lo que rompía `nz_clone_procedure`.

## Issue relacionado
Closes #79

## Acción según AGENTS.md
- **Ruta (keywords)**: DDL, sql_guard, regresión
- **Docs leídos**:
  - docs/architecture/security-model.md
  - docs/roles/data-engineer.md
  - docs/architecture/tools-contract.md
- **Rol asumido**: Security Engineer + Data Engineer

## Archivos esperados (según el issue)
- `src/nz_mcp/catalog/ddl.py`, `src/nz_mcp/sql_guard.py`, tests y `CHANGELOG.md` como en el issue; `docs/architecture/security-model.md` para documentar el tratamiento del cuerpo NZPLSQL.

## Auditoría pre-merge — 7 dimensiones
> Marca todas las casillas. Bloqueantes sin marcar = no merge.

### 1. Contrato y compatibilidad
- [x] Sin cambio de contrato de tools; `tools-contract.md` sin cambios.
- [x] `CHANGELOG.md` con entrada bilingüe en Unreleased.
- [x] Sin breaking change.

### 2. Seguridad
- [x] DDL sigue pasando por `sql_guard.validate()`.
- [x] Cabecera NZPLSQL validada; cuerpo opaco documentado en security-model.
- [x] Tests adversariales nuevos en cabecera NZPLSQL.

### 3. Mantenibilidad y diseño
- [x] Alcance acotado al issue #79.

### 4. Tests
- [x] `pytest -m "not integration"` verde.

### 5. Tipado y estilo
- [x] `ruff check` y `ruff format --check` limpios.
- [x] `mypy` limpio.

### 6. Documentación
- [x] `CHANGELOG.md` ES/EN.
- [x] `security-model.md` actualizado.

### 7. Idioma y forma
- [x] Título y commits en formato conventional commit (CI).

## Validación humana requerida
- [ ] No — cambios cubiertos por tests unitarios; integración opcional con Netezza real.

## Notas para el auditor
El scope del commit usa `sql-guard` (guión) en lugar de `sql_guard` porque el regex de CI solo permite `[a-z0-9-]+` en el scope.
