### PR TITLE
feat(ddl): dry_run y DROP IF EXISTS Netezza (issue 81)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ Cada entrada se documenta en **español** y **english**.
 
 ## [Unreleased]
 
+### Changed
+- ES: ``nz_create_table`` — por defecto ``dry_run=true``; para ejecutar en el servidor hace falta ``dry_run=false`` y ``confirm=true``. Salida alineada con otras tools DDL: ``ddl_to_execute``, ``executed``, ``duration_ms``.
+- EN: ``nz_create_table`` — defaults to ``dry_run=true``; execution requires ``dry_run=false`` and ``confirm=true``. Output aligned with other DDL tools: ``ddl_to_execute``, ``executed``, ``duration_ms``.
+
 ### Added
 - ES: tool ``nz_export_ddl`` — DDL de tabla/vista/procedimiento como bloques MCP (resource ``text/sql`` + texto resumen) y ``meta`` con URI ``nz-mcp://ddl/...``; pensada para copia nativa en clientes como Claude Desktop.
 - EN: ``nz_export_ddl`` tool — table/view/procedure DDL as MCP content blocks (``text/sql`` embedded resource + summary text) and ``meta`` with ``nz-mcp://ddl/...`` URI; intended for native copy UX in clients such as Claude Desktop.
@@ -25,6 +29,8 @@ Cada entrada se documenta en **español** y **english**.
 - EN: CLI command ``nz-mcp edit-profile`` to update mode/limits on an existing profile (``tomli-w`` dependency).
 
 ### Fixed
+- ES: ``nz_drop_table`` con ``if_exists=true`` — emite ``DROP TABLE esquema.tabla IF EXISTS`` (sintaxis Netezza NPS 11.x), no ``DROP TABLE IF EXISTS ...`` (error de parser en el servidor).
+- EN: ``nz_drop_table`` with ``if_exists=true`` — emits ``DROP TABLE schema.table IF EXISTS`` (Netezza NPS 11.x syntax), not ``DROP TABLE IF EXISTS ...`` (server parse error).
 - ES: ``nz_create_table`` / ``execute_create_table`` — columna con ``default`` omitido o ``null`` en JSON ya no falla; se omite la cláusula ``DEFAULT`` (equivalente a sin default). Rechazo explícito de ``default`` string con ``;`` (inyección).
 - EN: ``nz_create_table`` / ``execute_create_table`` — column with omitted or JSON ``null`` ``default`` no longer errors; the ``DEFAULT`` clause is omitted (same as no default). String defaults containing ``;`` are rejected (injection).
 - ES: ``sql_guard`` — ``CREATE PROCEDURE ... LANGUAGE NZPLSQL AS`` se valida por cabecera (modo ``admin``); el cuerpo NZPLSQL no se parsea con ``sqlglot``, desbloqueando ``nz_clone_procedure`` con DDL real.

--- a/docs/architecture/security-model.md
+++ b/docs/architecture/security-model.md
@@ -59,6 +59,10 @@
 
 `sqlglot` no clasifica cuerpos NZPLSQL reales (`DECLARE`, `BEGIN`/`END`, cursores, etc.). Para sentencias que contienen el marcador `LANGUAGE NZPLSQL AS`, el guard **no** intenta parsear el cuerpo: valida la cabecera con regex (firma `schema.procedimiento`, sin `;` en la cabecera) y los identificadores con las mismas reglas que el catálogo. El cuerpo se trata como **opaco**; no es texto libre arbitrario del LLM en los flujos soportados (p. ej. clonado desde DDL ya obtenido del catálogo del propio servidor). El riesgo de inyección se concentra en la cabecera; ahí se exige `admin` y se rechazan cabeceras malformadas o apiladas.
 
+#### ``DROP TABLE`` con ``IF EXISTS`` en sufijo (Netezza)
+
+NPS 11.x usa ``DROP TABLE esquema.tabla IF EXISTS``, no el orden ANSI ``DROP TABLE IF EXISTS esquema.tabla``. ``sqlglot`` no parsea la forma sufijo; el guard la reconoce con un patrón dedicado (identificadores validados, sin apilamiento) y la clasifica como ``DROP`` en modo ``admin``, igual que el resto de DDL administrativo.
+
 ### Reglas por modo
 
 | Statement kind | `read` | `write` | `admin` |

--- a/docs/architecture/tools-contract.md
+++ b/docs/architecture/tools-contract.md
@@ -428,8 +428,14 @@ Si `dry_run=false` sin `confirm=true` → código estable `CONFIRM_REQUIRED`.
 | `distribution` | object (optional) | `{type: HASH\|RANDOM, columns: [...]}` |
 | `organized_on` | array (optional) | |
 | `if_not_exists` | bool (default true) | |
+| `dry_run` | bool (default **true**) | Si `true`, solo devuelve el DDL que se ejecutaría. |
+| `confirm` | bool (**required if** `dry_run=false`) | Debe ser `true` para ejecutar cuando `dry_run=false`. |
 
-**Output**: `{ "created": true, "ddl_executed": "..." }`
+**Output** (dry-run `true`): `{ "dry_run": true, "ddl_to_execute": "...", "executed": false, "duration_ms": 0 }`
+
+**Output** (ejecución real): `{ "dry_run": false, "ddl_to_execute": "...", "executed": true, "duration_ms": T }`
+
+Si `dry_run=false` sin `confirm=true` → código estable `CONFIRM_REQUIRED`.
 
 ---
 
@@ -454,7 +460,7 @@ Si `dry_run=false` sin `confirm=true` → código estable `CONFIRM_REQUIRED`.
 | `schema` | string (required) | |
 | `table` | string (required) | |
 | `confirm` | bool (**required**, no default) | |
-| `if_exists` | bool (default true) | |
+| `if_exists` | bool (default true) | Emite sintaxis Netezza ``DROP TABLE schema.table IF EXISTS`` (sufijo). |
 
 **Output**: `{ "dropped": true }`
 
@@ -562,7 +568,8 @@ Cada tool declara `annotations` para que el cliente MCP muestre diálogos adecua
 | `nz_query_select`, `nz_explain`, `nz_list_*`, `nz_describe_*`, `nz_table_sample`, `nz_table_stats`, `nz_get_table_ddl`, `nz_get_view_ddl`, `nz_get_procedure_ddl`, `nz_export_ddl`, `nz_get_procedure_section`, `nz_current_profile` | true | false | true |
 | `nz_insert` | false | false | false |
 | `nz_update`, `nz_delete` | false | true | false |
-| `nz_create_table`, `nz_clone_procedure` | false | false | true |
+| `nz_create_table` | false | false | true |
+| `nz_clone_procedure` | false | false | true |
 | `nz_truncate`, `nz_drop_table` | false | **true** | true |
 | `nz_switch_profile` | false | false | true |
 

--- a/src/nz_mcp/catalog/ddl.py
+++ b/src/nz_mcp/catalog/ddl.py
@@ -139,8 +139,9 @@ def execute_create_table(
     distribution: dict[str, Any] | None,
     organized_on: list[str] | None,
     if_not_exists: bool,
+    dry_run: bool = False,
 ) -> dict[str, Any]:
-    """Build Netezza ``CREATE TABLE`` DDL, validate the parseable core, execute full DDL."""
+    """Build Netezza ``CREATE TABLE`` DDL, validate the parseable core, optionally execute."""
     _ensure_session_database(profile, database)
     base_sql = _build_create_table_base_sql(
         schema=schema,
@@ -162,8 +163,17 @@ def execute_create_table(
     pieces.append(dist_clause)
     full_sql = "\n".join(pieces)
 
+    if dry_run:
+        return {
+            "dry_run": True,
+            "ddl_to_execute": full_sql,
+            "executed": False,
+            "duration_ms": 0,
+        }
+
     password = get_password(profile.name)
     connection = cast(_ConnectionLike, open_connection(profile, password))
+    start = time.monotonic()
     try:
         with closing(connection.cursor()) as cursor:
             cursor.execute(full_sql, ())
@@ -176,7 +186,13 @@ def execute_create_table(
     finally:
         connection.close()
 
-    return {"created": True, "ddl_executed": full_sql}
+    duration_ms = int((time.monotonic() - start) * 1000)
+    return {
+        "dry_run": False,
+        "ddl_to_execute": full_sql,
+        "executed": True,
+        "duration_ms": duration_ms,
+    }
 
 
 def execute_truncate(
@@ -225,7 +241,8 @@ def execute_drop_table(
     """Execute ``DROP TABLE`` with ``sql_guard`` (admin)."""
     _ensure_session_database(profile, database)
     qual = _qualified_table(schema, table)
-    sql = f"DROP TABLE IF EXISTS {qual}" if if_exists else f"DROP TABLE {qual}"
+    # Netezza NPS expects ``DROP TABLE name IF EXISTS``, not ``DROP TABLE IF EXISTS name``.
+    sql = f"DROP TABLE {qual} IF EXISTS" if if_exists else f"DROP TABLE {qual}"
     parsed = guard_validate(sql, mode="admin")
     if parsed.kind is not StatementKind.DROP:
         raise NetezzaError(

--- a/src/nz_mcp/sql_guard.py
+++ b/src/nz_mcp/sql_guard.py
@@ -56,6 +56,13 @@ _NZPLSQL_PROC_HEAD: Final[re.Pattern[str]] = re.compile(
     r"(?:\s+RETURNS\b[\s\S]*)?\s*$",
     re.IGNORECASE | re.DOTALL,
 )
+# Netezza NPS places ``IF EXISTS`` after the qualified name (not ANSI ``DROP TABLE IF EXISTS ...``).
+_NETEZZA_DROP_TABLE_IF_EXISTS_SUFFIX: Final[re.Pattern[str]] = re.compile(
+    r"^\s*DROP\s+TABLE\s+"
+    r"(?P<sch>[A-Za-z][A-Za-z0-9_]*)\s*\.\s*(?P<tbl>[A-Za-z][A-Za-z0-9_]*)"
+    r"\s+IF\s+EXISTS\s*$",
+    re.IGNORECASE,
+)
 
 
 @dataclass(frozen=True, slots=True)
@@ -75,6 +82,9 @@ def validate(sql: str, *, mode: PermissionMode) -> ParsedStatement:
 
     if _NZPLSQL_MARKER.search(sql):
         return _validate_nzplsql_procedure(sql, mode=mode)
+
+    if _NETEZZA_DROP_TABLE_IF_EXISTS_SUFFIX.match(sql.strip()):
+        return _validate_netezza_drop_if_exists_suffix(sql, mode=mode)
 
     try:
         parsed_list = sqlglot.parse(sql, read="postgres")
@@ -145,6 +155,28 @@ def _validate_nzplsql_procedure(sql: str, *, mode: PermissionMode) -> ParsedStat
         ) from exc
 
     return ParsedStatement(kind=StatementKind.CREATE, has_where=False, raw=sql)
+
+
+def _validate_netezza_drop_if_exists_suffix(sql: str, *, mode: PermissionMode) -> ParsedStatement:
+    """Accept Netezza ``DROP TABLE schema.table IF EXISTS`` (suffix form)."""
+    m = _NETEZZA_DROP_TABLE_IF_EXISTS_SUFFIX.match(sql.strip())
+    if not m:
+        raise GuardRejectedError(
+            code="UNKNOWN_STATEMENT",
+            detail="Malformed Netezza DROP TABLE ... IF EXISTS.",
+        )
+
+    try:
+        validate_catalog_identifier(m.group("sch"))
+        validate_catalog_identifier(m.group("tbl"))
+    except InvalidInputError as exc:
+        raise GuardRejectedError(
+            code="UNKNOWN_STATEMENT",
+            detail="Invalid DROP TABLE identifier.",
+        ) from exc
+
+    _enforce(kind=StatementKind.DROP, has_where=False, mode=mode)
+    return ParsedStatement(kind=StatementKind.DROP, has_where=False, raw=sql)
 
 
 _SIMPLE_KIND_MAP: Final[tuple[tuple[type[exp.Expr], StatementKind], ...]] = (

--- a/src/nz_mcp/tools/ddl.py
+++ b/src/nz_mcp/tools/ddl.py
@@ -36,12 +36,16 @@ class CreateTableInput(BaseModel):
     distribution: DistributionInput | None = None
     organized_on: list[str] | None = None
     if_not_exists: bool = True
+    dry_run: bool = True
+    confirm: bool = False
 
 
 class CreateTableOutput(BaseModel):
     model_config = ConfigDict(extra="forbid")
-    created: bool
-    ddl_executed: str
+    dry_run: bool
+    ddl_to_execute: str
+    executed: bool
+    duration_ms: int
 
 
 class TruncateInput(BaseModel):
@@ -84,7 +88,8 @@ def _require_confirm_true(confirm: bool, *, tool: str) -> None:
     name="nz_create_table",
     description=(
         "Create a base table with validated identifiers and Netezza distribution. "
-        "Requires profile mode admin. Use for new tables only — not for ALTER."
+        "Requires profile mode admin. Default dry_run=true returns DDL only; set "
+        "dry_run=false and confirm=true to execute. Use for new tables only — not for ALTER."
     ),
     mode="admin",
     input_model=CreateTableInput,
@@ -103,6 +108,29 @@ def nz_create_table(
 ) -> CreateTableOutput:
     profile = get_active_profile(path=config_path)
     dist_dict = params.distribution.model_dump() if params.distribution is not None else None
+    if params.dry_run:
+        raw = execute_create_table(
+            profile,
+            database=params.database,
+            schema=params.table_schema,
+            table=params.table,
+            columns=[c.model_dump() for c in params.columns],
+            distribution=dist_dict,
+            organized_on=params.organized_on,
+            if_not_exists=params.if_not_exists,
+            dry_run=True,
+        )
+        return CreateTableOutput(
+            dry_run=True,
+            ddl_to_execute=str(raw["ddl_to_execute"]),
+            executed=False,
+            duration_ms=int(raw["duration_ms"]),
+        )
+    if params.confirm is not True:
+        raise InvalidInputError(
+            code="CONFIRM_REQUIRED",
+            detail="confirm=true is required when dry_run=false for nz_create_table.",
+        )
     raw = execute_create_table(
         profile,
         database=params.database,
@@ -112,8 +140,14 @@ def nz_create_table(
         distribution=dist_dict,
         organized_on=params.organized_on,
         if_not_exists=params.if_not_exists,
+        dry_run=False,
     )
-    return CreateTableOutput(created=bool(raw["created"]), ddl_executed=str(raw["ddl_executed"]))
+    return CreateTableOutput(
+        dry_run=False,
+        ddl_to_execute=str(raw["ddl_to_execute"]),
+        executed=bool(raw["executed"]),
+        duration_ms=int(raw["duration_ms"]),
+    )
 
 
 @tool(

--- a/tests/integration/test_issue81_ddl_smoke.py
+++ b/tests/integration/test_issue81_ddl_smoke.py
@@ -1,0 +1,60 @@
+"""Issue #81 optional smoke against a real Netezza profile (DDL dry_run / DROP IF EXISTS)."""
+
+from __future__ import annotations
+
+import os
+
+import pytest
+
+from nz_mcp.tools.ddl import (
+    ColumnDef,
+    CreateTableInput,
+    DistributionInput,
+    DropTableInput,
+    nz_create_table,
+    nz_drop_table,
+)
+
+pytestmark = pytest.mark.integration
+
+
+@pytest.mark.skipif(
+    os.environ.get("NZ_MCP_RUN_INTEGRATION") != "1",
+    reason="Set NZ_MCP_RUN_INTEGRATION=1 and configure a live admin profile.",
+)
+def test_issue81_create_table_dry_run_returns_ddl_only() -> None:
+    db = os.environ.get("NZ_MCP_TEST_DATABASE", "DESA_MODELOS")
+    schema = os.environ.get("NZ_MCP_TEST_SCHEMA", "DBO")
+    out = nz_create_table(
+        CreateTableInput(
+            database=db,
+            table_schema=schema,
+            table="NZ_MCP_ISSUE81_DRYRUN",
+            columns=[ColumnDef(name="ID", type="INT")],
+            distribution=DistributionInput(type="RANDOM", columns=[]),
+            dry_run=True,
+        ),
+    )
+    assert out.dry_run is True
+    assert out.executed is False
+    assert "CREATE TABLE" in out.ddl_to_execute
+    assert "DISTRIBUTE ON" in out.ddl_to_execute
+
+
+@pytest.mark.skipif(
+    os.environ.get("NZ_MCP_RUN_INTEGRATION") != "1",
+    reason="Set NZ_MCP_RUN_INTEGRATION=1 and configure a live admin profile.",
+)
+def test_issue81_drop_table_if_exists_missing_table_ok() -> None:
+    db = os.environ.get("NZ_MCP_TEST_DATABASE", "DESA_MODELOS")
+    schema = os.environ.get("NZ_MCP_TEST_SCHEMA", "DBO")
+    out = nz_drop_table(
+        DropTableInput(
+            database=db,
+            table_schema=schema,
+            table="NZ_MCP_NONEXISTENT_DROP_81",
+            confirm=True,
+            if_exists=True,
+        ),
+    )
+    assert out.dropped is True

--- a/tests/unit/test_catalog_ddl.py
+++ b/tests/unit/test_catalog_ddl.py
@@ -68,8 +68,8 @@ def test_execute_create_table_validates_core_and_distributes(
         organized_on=None,
         if_not_exists=True,
     )
-    assert out["created"] is True
-    sql = out["ddl_executed"]
+    assert out["executed"] is True
+    sql = out["ddl_to_execute"]
     assert "CREATE TABLE IF NOT EXISTS PUBLIC.T1" in sql
     assert "ID INTEGER NOT NULL" in sql
     assert "DISTRIBUTE ON RANDOM" in sql
@@ -94,7 +94,7 @@ def test_execute_create_table_hash_and_organize(monkeypatch: pytest.MonkeyPatch)
         organized_on=["ID"],
         if_not_exists=False,
     )
-    sql = str(out["ddl_executed"])
+    sql = str(out["ddl_to_execute"])
     assert "CREATE TABLE PUBLIC.T2" in sql
     assert "ORGANIZE ON (ID)" in sql
     assert "DISTRIBUTE ON HASH (ID)" in sql
@@ -130,7 +130,9 @@ def test_execute_truncate_and_drop(monkeypatch: pytest.MonkeyPatch) -> None:
 
     d_out = execute_drop_table(prof, "DEV", "PUBLIC", "T", if_exists=True)
     assert d_out["dropped"] is True
-    assert "DROP TABLE IF EXISTS PUBLIC.T" in fake.cursor_obj.executed[-1][0]
+    executed_sql = fake.cursor_obj.executed[-1][0]
+    assert "DROP TABLE PUBLIC.T IF EXISTS" in executed_sql
+    assert "IF EXISTS PUBLIC" not in executed_sql
 
 
 def test_execute_drop_table_if_not_exists_false(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -211,9 +213,39 @@ def test_create_table_column_without_default(monkeypatch: pytest.MonkeyPatch) ->
         organized_on=None,
         if_not_exists=True,
     )
-    sql = str(out["ddl_executed"])
+    sql = str(out["ddl_to_execute"])
     inner = sql.split("(", 1)[1].rsplit(")", 1)[0]
     assert "DEFAULT" not in inner
+
+
+def test_execute_create_table_dry_run_skips_connection(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    opened: list[object] = []
+
+    def _boom_open(_p: object, _w: object) -> object:
+        opened.append(True)
+        return _FakeConn()
+
+    monkeypatch.setattr("nz_mcp.catalog.ddl.open_connection", _boom_open)
+    monkeypatch.setattr("nz_mcp.catalog.ddl.get_password", lambda _n: "pw")
+    prof = _admin_profile()
+    out = execute_create_table(
+        prof,
+        database="DEV",
+        schema="PUBLIC",
+        table="DRY1",
+        columns=[{"name": "ID", "type": "INTEGER"}],
+        distribution=None,
+        organized_on=None,
+        if_not_exists=True,
+        dry_run=True,
+    )
+    assert out["dry_run"] is True
+    assert out["executed"] is False
+    assert out["duration_ms"] == 0
+    assert "CREATE TABLE" in out["ddl_to_execute"]
+    assert opened == []
 
 
 def test_create_table_column_explicit_null_default(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -234,7 +266,7 @@ def test_create_table_column_explicit_null_default(monkeypatch: pytest.MonkeyPat
         organized_on=None,
         if_not_exists=True,
     )
-    sql = str(out["ddl_executed"])
+    sql = str(out["ddl_to_execute"])
     inner = sql.split("(", 1)[1].rsplit(")", 1)[0]
     assert "DEFAULT" not in inner
 
@@ -254,7 +286,7 @@ def test_create_table_column_with_default_literal(monkeypatch: pytest.MonkeyPatc
         organized_on=None,
         if_not_exists=True,
     )
-    assert "DEFAULT 0" in str(out["ddl_executed"])
+    assert "DEFAULT 0" in str(out["ddl_to_execute"])
 
 
 def test_create_table_column_with_injection_in_default(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/unit/test_sql_guard.py
+++ b/tests/unit/test_sql_guard.py
@@ -168,3 +168,14 @@ def test_validate_create_table_without_language_nzplsql_not_header_only_path() -
     sql = "CREATE TABLE z (a INT)"
     assert "LANGUAGE" not in sql
     assert validate(sql, mode="admin").kind is StatementKind.CREATE
+
+
+def test_validate_netezza_drop_table_if_exists_suffix() -> None:
+    parsed = validate("DROP TABLE DBO.X IF EXISTS", mode="admin")
+    assert parsed.kind is StatementKind.DROP
+
+
+def test_validate_netezza_drop_if_exists_suffix_rejected_in_read() -> None:
+    with pytest.raises(GuardRejectedError) as exc:
+        validate("DROP TABLE DBO.X IF EXISTS", mode="read")
+    assert exc.value.code == "STATEMENT_NOT_ALLOWED"

--- a/tests/unit/test_tools_ddl.py
+++ b/tests/unit/test_tools_ddl.py
@@ -129,8 +129,10 @@ def test_nz_create_table_happy_mocked(monkeypatch: pytest.MonkeyPatch, tmp_path:
     monkeypatch.setattr(
         "nz_mcp.tools.ddl.execute_create_table",
         lambda *_a, **_k: {
-            "created": True,
-            "ddl_executed": "CREATE TABLE PUBLIC.X (ID INTEGER)\nDISTRIBUTE ON RANDOM",
+            "dry_run": False,
+            "ddl_to_execute": "CREATE TABLE PUBLIC.X (ID INTEGER)\nDISTRIBUTE ON RANDOM",
+            "executed": True,
+            "duration_ms": 5,
         },
     )
     out = nz_create_table(
@@ -139,11 +141,88 @@ def test_nz_create_table_happy_mocked(monkeypatch: pytest.MonkeyPatch, tmp_path:
             table_schema="PUBLIC",
             table="X",
             columns=[ColumnDef(name="ID", type="INTEGER")],
+            dry_run=False,
+            confirm=True,
         ),
         config_path=profiles,
     )
-    assert out.created is True
-    assert "DISTRIBUTE ON RANDOM" in out.ddl_executed
+    assert out.executed is True
+    assert out.dry_run is False
+    assert out.duration_ms == 5
+    assert "DISTRIBUTE ON RANDOM" in out.ddl_to_execute
+
+
+def test_nz_create_table_dry_run_skips_execute(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    home = tmp_path / "nz-mcp"
+    home.mkdir()
+    profiles = home / "profiles.toml"
+    profiles.write_text(
+        'active = "a"\n[profiles.a]\nhost="h"\nport=5480\ndatabase="DEV"\nuser="u"\nmode="admin"\n',
+        encoding="utf-8",
+    )
+    import nz_mcp.config as cfg
+
+    monkeypatch.setenv("NZ_MCP_HOME", str(home))
+    monkeypatch.setattr(cfg, "config_dir", lambda: home)
+    calls: list[bool] = []
+
+    def _stub(*_a: object, **kw: object) -> dict[str, object]:
+        dr = kw.get("dry_run", True)
+        calls.append(bool(dr))
+        return {
+            "dry_run": True,
+            "ddl_to_execute": "CREATE ...",
+            "executed": False,
+            "duration_ms": 0,
+        }
+
+    monkeypatch.setattr("nz_mcp.tools.ddl.execute_create_table", _stub)
+    out = nz_create_table(
+        CreateTableInput(
+            database="DEV",
+            table_schema="PUBLIC",
+            table="Y",
+            columns=[ColumnDef(name="ID", type="INTEGER")],
+        ),
+        config_path=profiles,
+    )
+    assert out.dry_run is True
+    assert out.executed is False
+    assert calls == [True]
+
+
+def test_nz_create_table_confirm_required_when_dry_run_false(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    home = tmp_path / "nz-mcp"
+    home.mkdir()
+    profiles = home / "profiles.toml"
+    profiles.write_text(
+        'active = "a"\n[profiles.a]\nhost="h"\nport=5480\ndatabase="DEV"\nuser="u"\nmode="admin"\n',
+        encoding="utf-8",
+    )
+    import nz_mcp.config as cfg
+
+    monkeypatch.setenv("NZ_MCP_HOME", str(home))
+    monkeypatch.setattr(cfg, "config_dir", lambda: home)
+
+    from nz_mcp.errors import InvalidInputError
+
+    with pytest.raises(InvalidInputError) as ei:
+        nz_create_table(
+            CreateTableInput(
+                database="DEV",
+                table_schema="PUBLIC",
+                table="Z",
+                columns=[ColumnDef(name="ID", type="INTEGER")],
+                dry_run=False,
+                confirm=False,
+            ),
+            config_path=profiles,
+        )
+    assert ei.value.code == "CONFIRM_REQUIRED"
 
 
 def test_nz_truncate_happy_mocked(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:


### PR DESCRIPTION
## ¿Qué cambia?
Alinea `nz_create_table` con el patrón DDL del resto de tools (`dry_run` por defecto, `confirm` para ejecutar) y corrige `nz_drop_table` con `if_exists` para la sintaxis real de Netezza NPS 11.x (`DROP TABLE esquema.tabla IF EXISTS`).

## Issue relacionado
Closes #81

## Acción según AGENTS.md
- **Ruta (keywords)**: DDL, sql_guard, tools-contract
- **Docs leídos**:
  - docs/architecture/tools-contract.md
  - docs/architecture/security-model.md
  - docs/roles/data-engineer.md
- **Rol asumido**: Data Engineer + Security Engineer

## Archivos esperados (según el issue)
- `src/nz_mcp/catalog/ddl.py`, `src/nz_mcp/sql_guard.py`, `src/nz_mcp/tools/ddl.py`, tests unitarios, `docs/architecture/tools-contract.md`, `CHANGELOG.md`, smoke opcional en `tests/integration/`.

## Auditoría pre-merge — 7 dimensiones
> Marca todas las casillas.

### 1. Contrato y compatibilidad
- [x] `docs/architecture/tools-contract.md` actualizado (`nz_create_table`, `nz_drop_table`).
- [x] `CHANGELOG.md` con entradas bilingües (Changed + Fixed).
- [x] Breaking change documentado: `nz_create_table` ahora requiere `dry_run=false` y `confirm=true` para ejecutar.

### 2. Seguridad
- [x] DDL sigue pasando por `sql_guard.validate()`.
- [x] Caso especial `DROP TABLE ... IF EXISTS` (sufijo) con identificadores validados.

### 3. Mantenibilidad y diseño
- [x] Alcance acotado al issue #81.

### 4. Tests
- [x] Tests nuevos para dry_run, confirm y sintaxis DROP.
- [x] `pytest -m "not integration"` verde.

### 5. Tipado y estilo
- [x] `ruff check` y `ruff format --check` limpios.
- [x] `mypy` limpio.

### 6. Documentación
- [x] `CHANGELOG.md` y `tools-contract.md` actualizados.

### 7. Idioma y forma
- [x] Título y commit en formato conventional commit.

## Validación humana requerida
- [ ] No — integración opcional con `NZ_MCP_RUN_INTEGRATION=1`.

## Notas para el auditor
`sqlglot` no parsea `DROP TABLE a.b IF EXISTS`; se añadió rama dedicada en `sql_guard` antes del parse genérico.
