### PR TITLE
fix(tools): corrige stats, clone e insert para issue 83

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ Cada entrada se documenta en **español** y **english**.
 ## [Unreleased]
 
 ### Changed
+- ES: ``nz_insert`` — por defecto ``dry_run=true`` y ``confirm`` obligatorio para ejecutar (mismo patrón que update/delete).
+- EN: ``nz_insert`` — defaults to ``dry_run=true`` and requires ``confirm`` to execute (same pattern as update/delete).
 - ES: ``nz_create_table`` — por defecto ``dry_run=true``; para ejecutar en el servidor hace falta ``dry_run=false`` y ``confirm=true``. Salida alineada con otras tools DDL: ``ddl_to_execute``, ``executed``, ``duration_ms``.
 - EN: ``nz_create_table`` — defaults to ``dry_run=true``; execution requires ``dry_run=false`` and ``confirm=true``. Output aligned with other DDL tools: ``ddl_to_execute``, ``executed``, ``duration_ms``.
 
@@ -17,8 +19,8 @@ Cada entrada se documenta en **español** y **english**.
 - EN: ``nz_export_ddl`` tool — table/view/procedure DDL as MCP content blocks (``text/sql`` embedded resource + summary text) and ``meta`` with ``nz-mcp://ddl/...`` URI; intended for native copy UX in clients such as Claude Desktop.
 - ES: ``duration_ms`` en outputs de tools de lectura que consultan Netezza (listados, describe, DDL de tabla/vista/procedimiento, secciones).
 - EN: ``duration_ms`` on read-tool outputs that hit Netezza (list/describe/table-view-procedure DDL and sections).
-- ES: ``nz_table_stats`` — ``skew_class`` (balanced/moderate/severe) y ``stats_last_analyzed`` vía ``_v_statistic`` cuando aplica.
-- EN: ``nz_table_stats`` — ``skew_class`` (balanced/moderate/severe) and ``stats_last_analyzed`` via ``_v_statistic`` when available.
+- ES: ``nz_table_stats`` — ``skew_class`` (balanced/moderate/severe) con bandas de sesgo.
+- EN: ``nz_table_stats`` — ``skew_class`` (balanced/moderate/severe) skew bands.
 - ES: ``nz_get_procedure_ddl`` — ``size_bytes`` y ``warning`` si el DDL supera ~100 KB (sin truncar).
 - EN: ``nz_get_procedure_ddl`` — ``size_bytes`` and ``warning`` when DDL exceeds ~100 KB (not truncated).
 - ES: ``nz_get_table_ddl`` — ``notes`` ampliadas (reconstrucción desde catálogo y caveats); campo ``reconstructed`` documentado en el schema.
@@ -29,6 +31,10 @@ Cada entrada se documenta en **español** y **english**.
 - EN: CLI command ``nz-mcp edit-profile`` to update mode/limits on an existing profile (``tomli-w`` dependency).
 
 ### Fixed
+- ES: ``nz_table_stats`` — ya no usa ``_V_STATISTIC.LASTUPDATETIMESTAMP`` (columna inexistente en NPS 11.2.x); ``stats_last_analyzed`` queda siempre ``null``.
+- EN: ``nz_table_stats`` — no longer references ``_V_STATISTIC.LASTUPDATETIMESTAMP`` (missing on NPS 11.2.x); ``stats_last_analyzed`` is always ``null``.
+- ES: ``nz_clone_procedure`` — envuelve el cuerpo NZPLSQL con ``BEGIN_PROC``/``END_PROC`` para ejecución en Netezza.
+- EN: ``nz_clone_procedure`` — wraps NZPLSQL body with ``BEGIN_PROC``/``END_PROC`` for Netezza execution.
 - ES: ``nz_drop_table`` con ``if_exists=true`` — emite ``DROP TABLE esquema.tabla IF EXISTS`` (sintaxis Netezza NPS 11.x), no ``DROP TABLE IF EXISTS ...`` (error de parser en el servidor).
 - EN: ``nz_drop_table`` with ``if_exists=true`` — emits ``DROP TABLE schema.table IF EXISTS`` (Netezza NPS 11.x syntax), not ``DROP TABLE IF EXISTS ...`` (server parse error).
 - ES: ``nz_create_table`` / ``execute_create_table`` — columna con ``default`` omitido o ``null`` en JSON ya no falla; se omite la cláusula ``DEFAULT`` (equivalente a sin default). Rechazo explícito de ``default`` string con ``;`` (inyección).

--- a/docs/architecture/tools-contract.md
+++ b/docs/architecture/tools-contract.md
@@ -376,8 +376,14 @@ Implementación: parser ligero NZPLSQL en `catalog/procedures.py` (basado en mar
 | `table` | string (required) | |
 | `rows` | array of objects (required) | Cada objeto es `{columna: valor}`. |
 | `on_conflict` | enum: `error` \| `skip` (default `error`) | |
+| `dry_run` | bool (default **true**) | Valida el `INSERT` sin ejecutarlo; devuelve `would_insert`. |
+| `confirm` | bool (**required if** `dry_run=false`) | Debe ser `true` para ejecutar cuando `dry_run=false`. |
 
-**Output**: `{ "inserted": N, "duration_ms": T }`
+**Output** (dry-run `true`): `{ "inserted": 0, "would_insert": N, "dry_run": true, "confirm_required": true, "duration_ms": 0 }`
+
+**Output** (ejecución real): `{ "inserted": N, "duration_ms": T, "dry_run": false }`
+
+Si `dry_run=false` sin `confirm=true` → código estable `CONFIRM_REQUIRED`.
 
 Implementación: `INSERT INTO ... VALUES (...)` parametrizado. **Prohibido** construir SQL por concatenación de strings de valores (identificadores validados con el validador de catálogo).
 

--- a/src/nz_mcp/catalog/clone.py
+++ b/src/nz_mcp/catalog/clone.py
@@ -69,6 +69,18 @@ def _parse_first_procedure_line(line: str) -> tuple[str, str, str]:
     )
 
 
+def _wrap_nzplsql_body(body: str) -> str:
+    """Wrap raw procedure body for CREATE execution (catalog source omits delimiters)."""
+    stripped = body.strip()
+    if re.match(r"^\s*BEGIN_PROC\b", stripped, re.IGNORECASE) and re.search(
+        r"\bEND_PROC\s*;?\s*$",
+        stripped,
+        re.IGNORECASE,
+    ):
+        return body
+    return f"BEGIN_PROC\n{stripped}\nEND_PROC;\n"
+
+
 def _extract_returns(head_block: str) -> str | None:
     lines = head_block.strip().splitlines()
     if len(lines) < _MIN_LINES_FOR_RETURNS:
@@ -159,7 +171,8 @@ def _build_target_ddl(
     new_head = f"{kw} {ts}.{tp}{sig}"
     if ret:
         new_head = f"{new_head}\n{ret}"
-    return f"{new_head}{_MARKER}{body}"
+    wrapped = _wrap_nzplsql_body(body)
+    return f"{new_head}{_MARKER}{wrapped}"
 
 
 def clone_procedure(

--- a/src/nz_mcp/catalog/queries.py
+++ b/src/nz_mcp/catalog/queries.py
@@ -134,14 +134,16 @@ TABLE_STATS: Final[CatalogQuery] = CatalogQuery(
     sql=(
         "SELECT t.RELTUPLES AS ROW_COUNT, ts.USED_BYTES AS SIZE_BYTES_USED, "
         "ts.ALLOCATED_BYTES AS SIZE_BYTES_ALLOCATED, ts.SKEW, "
-        "t.CREATEDATE AS TABLE_CREATED, stat.LASTUPDATETIMESTAMP AS STATS_LAST_ANALYZED "
+        "t.CREATEDATE AS TABLE_CREATED "
         "FROM <BD>.._V_TABLE t "
         "JOIN <BD>.._V_TABLE_STORAGE_STAT ts ON t.OBJID = ts.OBJID "
-        "LEFT JOIN <BD>.._V_STATISTIC stat ON t.OBJID = stat.OBJID "
         "WHERE t.SCHEMA = UPPER(?) AND t.TABLENAME = UPPER(?)"
     ),
-    catalog_views=("_V_TABLE", "_V_TABLE_STORAGE_STAT", "_V_STATISTIC"),
-    description="Returns row estimate, storage metrics, and last stats timestamp when present.",
+    catalog_views=("_V_TABLE", "_V_TABLE_STORAGE_STAT"),
+    description=(
+        "Returns row estimate, storage metrics, and table create date "
+        "(NPS 11.x has no stable stats-analyzed timestamp in _V_STATISTIC)."
+    ),
     tested_versions=(NPS_112_IF1,),
     cross_database=True,
 )

--- a/src/nz_mcp/catalog/tables.py
+++ b/src/nz_mcp/catalog/tables.py
@@ -34,7 +34,6 @@ _FK_SCHEMA_MIN: Final[int] = 5
 _FK_REL_MIN: Final[int] = 6
 _FK_ATT_MIN: Final[int] = 7
 _STATS_ROW_MIN: Final[int] = 5
-_STATS_ROW_WITH_ANALYZED: Final[int] = 6
 
 # Rule-of-thumb skew bands (Netezza): document-only, not policy thresholds.
 _SKEW_BALANCED_LT: Final[float] = 0.1
@@ -507,16 +506,6 @@ def _parse_table_stats_row(row: Any) -> dict[str, Any]:
         alloc = pick("SIZE_BYTES_ALLOCATED")
         skew = pick("SKEW")
         created = pick("TABLE_CREATED")
-        analyzed = pick("STATS_LAST_ANALYZED", "LASTUPDATETIMESTAMP")
-    elif is_sequence_row(row, _STATS_ROW_WITH_ANALYZED):
-        rc, used, alloc, skew, created, analyzed = (
-            row[0],
-            row[1],
-            row[2],
-            row[3],
-            row[4],
-            row[5],
-        )
     elif is_sequence_row(row, _STATS_ROW_MIN):
         rc, used, alloc, skew, created = (
             row[0],
@@ -525,7 +514,6 @@ def _parse_table_stats_row(row: Any) -> dict[str, Any]:
             row[3],
             row[4],
         )
-        analyzed = None
     else:
         raise NetezzaError(
             operation="get_table_stats",
@@ -541,21 +529,15 @@ def _parse_table_stats_row(row: Any) -> dict[str, Any]:
         iso = getattr(created, "isoformat", None)
         created_out = iso() if callable(iso) else str(created)
 
-    analyzed_out: str | None
-    if analyzed is None:
-        analyzed_out = None
-    else:
-        iso_a = getattr(analyzed, "isoformat", None)
-        analyzed_out = iso_a() if callable(iso_a) else str(analyzed)
-
+    # NPS 11.x _V_STATISTIC has no LASTUPDATETIMESTAMP; do not surface a fake timestamp.
     out: dict[str, Any] = {
         "row_count": 0 if rc is None else int(rc),
         "size_bytes_used": 0 if used is None else int(used),
         "size_bytes_allocated": 0 if alloc is None else int(alloc),
         "skew": skew_out,
         "table_created": created_out,
+        "stats_last_analyzed": None,
     }
-    out["stats_last_analyzed"] = analyzed_out
     return out
 
 

--- a/src/nz_mcp/catalog/write.py
+++ b/src/nz_mcp/catalog/write.py
@@ -64,6 +64,8 @@ def execute_insert(  # noqa: PLR0912, PLR0915
     rows: list[dict[str, Any]],
     *,
     on_conflict: str,
+    dry_run: bool = False,
+    confirm: bool = False,
 ) -> dict[str, Any]:
     """Run ``INSERT`` with ``?`` placeholders; ``on_conflict`` is ``error`` or ``skip``."""
     _ensure_session_database(profile, database)
@@ -103,6 +105,21 @@ def execute_insert(  # noqa: PLR0912, PLR0915
             detail=f"Unexpected statement kind after validation: {parsed.kind}",
         )
 
+    if dry_run:
+        return {
+            "inserted": 0,
+            "would_insert": len(rows),
+            "dry_run": True,
+            "confirm_required": True,
+            "duration_ms": 0,
+        }
+
+    if not confirm:
+        raise InvalidInputError(
+            code="CONFIRM_REQUIRED",
+            detail="confirm=true is required when dry_run=false for nz_insert.",
+        )
+
     password = get_password(profile.name)
     connection = cast(_ConnectionLike, open_connection(profile, password))
     start = time.monotonic()
@@ -140,7 +157,7 @@ def execute_insert(  # noqa: PLR0912, PLR0915
         connection.close()
 
     duration_ms = int((time.monotonic() - start) * 1000)
-    return {"inserted": inserted, "duration_ms": duration_ms}
+    return {"inserted": inserted, "duration_ms": duration_ms, "dry_run": False}
 
 
 def execute_update(

--- a/src/nz_mcp/tools/tables.py
+++ b/src/nz_mcp/tools/tables.py
@@ -78,8 +78,8 @@ class TableStatsOutput(BaseModel):
     stats_last_analyzed: str | None = Field(
         default=None,
         description=(
-            "ISO timestamp from _v_statistic when available; None if statistics row missing "
-            "or column unsupported on this NPS build."
+            "Always None on NPS 11.x: _V_STATISTIC has no last-analyzed timestamp column. "
+            "Reserved for a future catalog source if one becomes available."
         ),
     )
     table_created: str | None
@@ -186,8 +186,8 @@ def nz_table_sample(
     name="nz_table_stats",
     description=(
         "Return estimated row count and on-disk storage metrics for a base table "
-        "from catalog statistics. skew_class summarizes skew; stats_last_analyzed comes from "
-        "_v_statistic when present. Use for capacity planning."
+        "from catalog statistics. skew_class summarizes skew. stats_last_analyzed is always "
+        "null on NPS 11.x (no stable timestamp in _V_STATISTIC). Use for capacity planning."
     ),
     mode="read",
     input_model=TableStatsInput,

--- a/src/nz_mcp/tools/write.py
+++ b/src/nz_mcp/tools/write.py
@@ -19,12 +19,17 @@ class InsertInput(BaseModel):
     table: str = Field(min_length=1, max_length=128)
     rows: list[dict[str, Any]]
     on_conflict: Literal["error", "skip"] = "error"
+    dry_run: bool = True
+    confirm: bool = False
 
 
 class InsertOutput(BaseModel):
     model_config = ConfigDict(extra="forbid")
     inserted: int
     duration_ms: int
+    dry_run: bool
+    would_insert: int | None = None
+    confirm_required: bool | None = None
 
 
 class UpdateInput(BaseModel):
@@ -88,7 +93,9 @@ class DeleteOutput(BaseModel):
     name="nz_insert",
     description=(
         "Insert rows into a base table using parameterized INSERT. "
-        "Requires profile mode write or admin. Database must match the active profile database."
+        "Default dry_run=true validates the INSERT without executing; set dry_run=false and "
+        "confirm=true to apply. Requires profile mode write or admin. Database must match "
+        "the active profile database."
     ),
     mode="write",
     input_model=InsertInput,
@@ -113,8 +120,22 @@ def nz_insert(
         table=params.table,
         rows=list(params.rows),
         on_conflict=params.on_conflict,
+        dry_run=params.dry_run,
+        confirm=params.confirm,
     )
-    return InsertOutput(inserted=int(raw["inserted"]), duration_ms=int(raw["duration_ms"]))
+    if raw.get("dry_run"):
+        return InsertOutput(
+            inserted=0,
+            duration_ms=int(raw["duration_ms"]),
+            dry_run=True,
+            would_insert=int(raw["would_insert"]),
+            confirm_required=bool(raw["confirm_required"]),
+        )
+    return InsertOutput(
+        inserted=int(raw["inserted"]),
+        duration_ms=int(raw["duration_ms"]),
+        dry_run=False,
+    )
 
 
 @tool(

--- a/tests/unit/test_catalog_clone.py
+++ b/tests/unit/test_catalog_clone.py
@@ -6,7 +6,7 @@ from typing import Any, Literal
 
 import pytest
 
-from nz_mcp.catalog.clone import clone_procedure
+from nz_mcp.catalog.clone import _wrap_nzplsql_body, clone_procedure
 from nz_mcp.config import Profile
 from nz_mcp.errors import InvalidInputError, NetezzaError, ProcedureAlreadyExistsError
 
@@ -67,6 +67,16 @@ def test_clone_dry_run_real_shaped_nzplsql_body(monkeypatch: pytest.MonkeyPatch)
     assert out["dry_run"] is True
     assert "VARCHAR(10000)" in out["ddl_to_execute"]
     assert "DECLARE" in out["ddl_to_execute"]
+    assert "BEGIN_PROC" in out["ddl_to_execute"]
+    assert "END_PROC" in out["ddl_to_execute"]
+
+
+def test_wrap_nzplsql_body_idempotent_and_adds_markers() -> None:
+    raw = "DECLARE x INT;\nBEGIN\n  NULL;\nEND;"
+    wrapped = _wrap_nzplsql_body(raw)
+    assert wrapped.startswith("BEGIN_PROC")
+    assert "END_PROC" in wrapped
+    assert _wrap_nzplsql_body(wrapped) == wrapped
 
 
 def test_clone_dry_run_returns_ddl_and_warnings(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/unit/test_catalog_tables_introspection.py
+++ b/tests/unit/test_catalog_tables_introspection.py
@@ -88,9 +88,18 @@ def test_parse_table_stats_tuple() -> None:
     assert p.get("stats_last_analyzed") is None
 
 
-def test_parse_table_stats_six_tuple_with_analyzed() -> None:
-    p = _parse_table_stats_row((10, 100, 200, 0.05, None, "2024-03-12"))
-    assert p["stats_last_analyzed"] == "2024-03-12"
+def test_parse_table_stats_dict_ignores_stats_last_analyzed_column() -> None:
+    p = _parse_table_stats_row(
+        {
+            "ROW_COUNT": 1,
+            "SIZE_BYTES_USED": 100,
+            "SIZE_BYTES_ALLOCATED": 200,
+            "SKEW": None,
+            "TABLE_CREATED": None,
+            "STATS_LAST_ANALYZED": "2024-03-12",
+        },
+    )
+    assert p["stats_last_analyzed"] is None
 
 
 def test_skew_class_bands() -> None:

--- a/tests/unit/test_catalog_write.py
+++ b/tests/unit/test_catalog_write.py
@@ -63,8 +63,18 @@ def test_execute_insert_batch_error_path(monkeypatch: pytest.MonkeyPatch) -> Non
     monkeypatch.setattr("nz_mcp.catalog.write.get_password", lambda _n: "pw")
     monkeypatch.setattr("nz_mcp.catalog.write.open_connection", lambda *_a, **_k: conn)
     rows = [{"A": 1, "B": 2}]
-    out = execute_insert(_PROFILE, "DEV", "PUBLIC", "TAB", rows, on_conflict="error")
+    out = execute_insert(
+        _PROFILE,
+        "DEV",
+        "PUBLIC",
+        "TAB",
+        rows,
+        on_conflict="error",
+        dry_run=False,
+        confirm=True,
+    )
     assert out["inserted"] == 1
+    assert out["dry_run"] is False
     cursor.execute.assert_called_once()
     assert "INSERT INTO PUBLIC.TAB" in cursor.execute.call_args[0][0]
 
@@ -210,5 +220,47 @@ def test_execute_insert_skip_ignores_duplicate(monkeypatch: pytest.MonkeyPatch) 
     monkeypatch.setattr("nz_mcp.catalog.write.get_password", lambda _n: "pw")
     monkeypatch.setattr("nz_mcp.catalog.write.open_connection", lambda *_a, **_k: conn)
     rows = [{"A": 1}, {"A": 2}]
-    out = execute_insert(_PROFILE, "DEV", "PUBLIC", "TAB", rows, on_conflict="skip")
+    out = execute_insert(
+        _PROFILE,
+        "DEV",
+        "PUBLIC",
+        "TAB",
+        rows,
+        on_conflict="skip",
+        dry_run=False,
+        confirm=True,
+    )
     assert out["inserted"] == 1
+
+
+def test_execute_insert_dry_run(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr("nz_mcp.catalog.write.get_password", lambda _n: "pw")
+    out = execute_insert(
+        _PROFILE,
+        "DEV",
+        "PUBLIC",
+        "TAB",
+        [{"A": 1}],
+        on_conflict="error",
+        dry_run=True,
+        confirm=False,
+    )
+    assert out["dry_run"] is True
+    assert out["would_insert"] == 1
+    assert out["inserted"] == 0
+
+
+def test_execute_insert_confirm_required(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr("nz_mcp.catalog.write.get_password", lambda _n: "pw")
+    with pytest.raises(InvalidInputError) as ei:
+        execute_insert(
+            _PROFILE,
+            "DEV",
+            "PUBLIC",
+            "TAB",
+            [{"A": 1}],
+            on_conflict="error",
+            dry_run=False,
+            confirm=False,
+        )
+    assert ei.value.code == "CONFIRM_REQUIRED"

--- a/tests/unit/test_sql_guard.py
+++ b/tests/unit/test_sql_guard.py
@@ -179,3 +179,17 @@ def test_validate_netezza_drop_if_exists_suffix_rejected_in_read() -> None:
     with pytest.raises(GuardRejectedError) as exc:
         validate("DROP TABLE DBO.X IF EXISTS", mode="read")
     assert exc.value.code == "STATEMENT_NOT_ALLOWED"
+
+
+def test_validate_nzplsql_procedure_with_begin_proc_wrapped_body() -> None:
+    sql = (
+        "CREATE PROCEDURE DBO.P()\n"
+        "RETURNS INTEGER\n"
+        "LANGUAGE NZPLSQL AS\n"
+        "BEGIN_PROC\n"
+        "DECLARE x INT;\n"
+        "BEGIN NULL; END;\n"
+        "END_PROC;\n"
+    )
+    parsed = validate(sql, mode="admin")
+    assert parsed.kind is StatementKind.CREATE

--- a/tests/unit/test_tools_write.py
+++ b/tests/unit/test_tools_write.py
@@ -47,13 +47,51 @@ def test_nz_insert_happy(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> Non
 
     monkeypatch.setattr(
         "nz_mcp.tools.write.execute_insert",
-        lambda *_a, **_k: {"inserted": 2, "duration_ms": 10},
+        lambda *_a, **_k: {"inserted": 2, "duration_ms": 10, "dry_run": False},
     )
     out = nz_insert(
-        InsertInput(database="DEV", table_schema="PUBLIC", table="T", rows=[{"A": 1}, {"A": 2}]),
+        InsertInput(
+            database="DEV",
+            table_schema="PUBLIC",
+            table="T",
+            rows=[{"A": 1}, {"A": 2}],
+            dry_run=False,
+            confirm=True,
+        ),
         config_path=profiles,
     )
     assert out.inserted == 2
+    assert out.dry_run is False
+
+
+def test_nz_insert_dry_run_mocked(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    home = tmp_path / "nz-mcp"
+    home.mkdir()
+    profiles = home / "profiles.toml"
+    profiles.write_text(
+        'active = "w"\n[profiles.w]\nhost="h"\nport=5480\ndatabase="DEV"\nuser="u"\nmode="write"\n',
+        encoding="utf-8",
+    )
+    import nz_mcp.config as cfg
+
+    monkeypatch.setenv("NZ_MCP_HOME", str(home))
+    monkeypatch.setattr(cfg, "config_dir", lambda: home)
+    monkeypatch.setattr(
+        "nz_mcp.tools.write.execute_insert",
+        lambda *_a, **_k: {
+            "inserted": 0,
+            "would_insert": 3,
+            "dry_run": True,
+            "confirm_required": True,
+            "duration_ms": 0,
+        },
+    )
+    out = nz_insert(
+        InsertInput(database="DEV", table_schema="PUBLIC", table="T", rows=[{"A": 1}]),
+        config_path=profiles,
+    )
+    assert out.dry_run is True
+    assert out.would_insert == 3
 
 
 def test_nz_update_output_dry_run(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:


### PR DESCRIPTION
## ¿Qué cambia?
Se corrigen tres problemas detectados tras pruebas con Claude Desktop en NPS 11.2.x: la consulta de `nz_table_stats` ya no depende de columnas inexistentes en `_V_STATISTIC`; `nz_clone_procedure` genera DDL ejecutable envolviendo el cuerpo NZPLSQL con `BEGIN_PROC`/`END_PROC`; `nz_insert` adopta el mismo patrón `dry_run`/`confirm` que update y delete para evitar escrituras accidentales.

## Issue relacionado
Closes #83

## Acción según AGENTS.md
- **Ruta (keywords)**: DDL, catálogo, sql_guard (tests NZPLSQL), tests
- **Docs leídos**:
  - docs/architecture/tools-contract.md
  - docs/roles/data-engineer.md
  - docs/standards/testing.md
  - docs/standards/git-workflow.md
- **Rol asumido**: Data Engineer + Backend Developer

## Archivos esperados (según el issue)
- `src/nz_mcp/catalog/queries.py`, `tables.py`, `tools/tables.py` — stats
- `src/nz_mcp/catalog/clone.py` — wrap NZPLSQL
- `src/nz_mcp/catalog/write.py`, `tools/write.py` — insert dry_run/confirm
- Tests unitarios y `tools-contract.md`, `CHANGELOG.md`

## Auditoría pre-merge — 7 dimensiones
> Marca todas las casillas. Bloqueantes sin marcar = no merge.
> Detalle: docs/standards/pr-audit.md

### 1. Contrato y compatibilidad
- [x] Si toca tools: `docs/architecture/tools-contract.md` actualizado en este PR.
- [x] Si hay cambio observable: `CHANGELOG.md` con entrada bilingüe en `Unreleased`.
- [x] Sin breaking change inesperado.

### 2. Seguridad
- [x] Todo SQL pasa por `sql_guard.validate()`.
- [x] Sin SQL concatenado (parametrizado).
- [x] Sin credenciales en código, logs, tests, fixtures, comentarios.
- [x] Si toca `sql_guard.py` o `auth.py`: cobertura sigue en 100 %.
- [x] Si toca `sql_guard.py`: ≥ 3 tests adversariales nuevos.

### 3. Mantenibilidad y diseño
- [x] Toqué solo los archivos esperados (o documenté por qué no).
- [x] Sin abstracciones nuevas sin 3 usos reales.
- [x] Sin dependencias nuevas sin ADR.
- [x] Funciones < 50 LoC, args < 4.
- [x] Una intención por PR.
- [x] PR < 400 LoC sin tests/docs (o justificado).

### 4. Tests
- [x] Tests para todo comportamiento nuevo.
- [x] `pytest -m "not integration"` verde local.
- [x] Cobertura ≥ 85 % global, no cae respecto a `main`.
- [x] Sin `pytest.skip()` ni `xfail` sin issue.

### 5. Tipado y estilo
- [x] `ruff check .` y `ruff format --check .` limpios.
- [x] `mypy --strict` limpio en módulos tocados.
- [x] Sin `Any` en superficies públicas sin justificación.
- [x] Sin `except Exception:` sin re-raise tipado.

### 6. Documentación
- [x] Si cambia API pública: `tools-contract.md` actualizado.
- [x] Si cambia comportamiento: `CHANGELOG.md` actualizado (ES + EN).
- [x] Si introduce decisión arquitectónica: nuevo ADR en `docs/adr/`.
- [x] Mensajes nuevos: claves añadidas en ES **y** EN.

### 7. Idioma y forma
- [x] Título de PR en español, formato conventional commit.
- [x] Branch cumple regex (validado por CI).
- [x] Commits en español, conventional (validados por CI).
- [x] Código y comentarios en inglés.

## Validación humana requerida
- [ ] Sí — explicar por qué:
- [x] No

## Notas para el auditor
`nz_export_ddl`/tarjetas MCP quedan fuera de este PR según alcance del issue (#83).