### PR TITLE
fix(server): enruta structlog a stderr para MCP stdio (issue 86)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,8 @@ Cada entrada se documenta en **español** y **english**.
 - EN: CLI command ``nz-mcp edit-profile`` to update mode/limits on an existing profile (``tomli-w`` dependency).
 
 ### Fixed
+- ES: servidor MCP stdio — ``structlog`` y logging estándar se configuran hacia ``stderr`` al arrancar ``serve`` / ``run_stdio_server``, evitando que Claude Desktop falle al parsear JSON-RPC por texto no JSON en ``stdout`` (issue #86).
+- EN: MCP stdio server — ``structlog`` and stdlib logging are configured to ``stderr`` when starting ``serve`` / ``run_stdio_server``, preventing Claude Desktop JSON-RPC parse errors from non-JSON text on ``stdout`` (issue #86).
 - ES: ``nz_table_stats`` — ya no usa ``_V_STATISTIC.LASTUPDATETIMESTAMP`` (columna inexistente en NPS 11.2.x); ``stats_last_analyzed`` queda siempre ``null``.
 - EN: ``nz_table_stats`` — no longer references ``_V_STATISTIC.LASTUPDATETIMESTAMP`` (missing on NPS 11.2.x); ``stats_last_analyzed`` is always ``null``.
 - ES: ``nz_clone_procedure`` — envuelve el cuerpo NZPLSQL con ``BEGIN_PROC``/``END_PROC`` para ejecución en Netezza.

--- a/src/nz_mcp/cli.py
+++ b/src/nz_mcp/cli.py
@@ -45,6 +45,7 @@ from nz_mcp.errors import (
     ProfileNotFoundError,
 )
 from nz_mcp.i18n import MESSAGES, resolve_locale, t
+from nz_mcp.logging_config import configure_logging_for_stdio
 from nz_mcp.logging_utils import sanitize
 from nz_mcp.server import run_stdio_server
 
@@ -257,6 +258,7 @@ def test_connection_cmd(
 @app.command("serve")
 def serve_cmd() -> None:
     """Run the MCP server over stdio."""
+    configure_logging_for_stdio()
     run_stdio_server()
 
 

--- a/src/nz_mcp/logging_config.py
+++ b/src/nz_mcp/logging_config.py
@@ -1,0 +1,52 @@
+"""Logging setup for MCP stdio transport: JSON-RPC must own stdout; logs go to stderr."""
+
+from __future__ import annotations
+
+import logging
+import sys
+import warnings
+from typing import Final
+
+import structlog
+
+_state: dict[str, bool] = {"configured": False}
+
+
+def configure_logging_for_stdio() -> None:
+    """Route stdlib logging and structlog to stderr so stdout stays JSON-RPC only.
+
+    Call once when entering stdio server mode (``run_stdio_server`` / ``serve`` CLI).
+    Idempotent: repeated calls are no-ops.
+    """
+    if _state["configured"]:
+        return
+    _state["configured"] = True
+
+    root = logging.getLogger()
+    if not root.handlers:
+        logging.basicConfig(
+            stream=sys.stderr,
+            level=logging.INFO,
+            format="%(asctime)s [%(levelname)s] %(name)s: %(message)s",
+        )
+    logging.captureWarnings(True)
+
+    warnings.filterwarnings(
+        "ignore",
+        category=UserWarning,
+        module=r"sqlglot\..*",
+    )
+
+    structlog.configure(
+        processors=[
+            structlog.processors.add_log_level,
+            structlog.processors.TimeStamper(fmt="iso"),
+            structlog.processors.JSONRenderer(),
+        ],
+        wrapper_class=structlog.make_filtering_bound_logger(logging.INFO),
+        logger_factory=structlog.PrintLoggerFactory(file=sys.stderr),
+        cache_logger_on_first_use=True,
+    )
+
+
+__all__: Final[tuple[str, ...]] = ("configure_logging_for_stdio",)

--- a/src/nz_mcp/server.py
+++ b/src/nz_mcp/server.py
@@ -19,6 +19,7 @@ from nz_mcp import __version__
 from nz_mcp.config import Profile, get_active_profile
 from nz_mcp.errors import InvalidInputError, NzMcpError, PermissionDeniedError
 from nz_mcp.i18n import MESSAGES, both
+from nz_mcp.logging_config import configure_logging_for_stdio
 from nz_mcp.tools.registry import TOOLS, OutputKind, ToolSpec
 
 _MODE_RANK = {"read": 0, "write": 1, "admin": 2}
@@ -202,6 +203,7 @@ def build_mcp_server(*, config_path: Path | None = None) -> Server[Any, Any]:
 
 def run_stdio_server(*, config_path: Path | None = None) -> None:
     """Run the MCP server on stdio using the official MCP SDK transport."""
+    configure_logging_for_stdio()
     anyio.run(_run_stdio_server_async, config_path)
 
 

--- a/tests/contract/test_stdio_stdout_json_lines.py
+++ b/tests/contract/test_stdio_stdout_json_lines.py
@@ -1,0 +1,49 @@
+"""Contract: MCP stdio JSON-RPC must not be mixed with log text on stdout (issue #86)."""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+
+def _project_root() -> Path:
+    return Path(__file__).resolve().parents[2]
+
+
+def _env_for_subprocess() -> dict[str, str]:
+    env = os.environ.copy()
+    src = str(_project_root() / "src")
+    env["PYTHONPATH"] = src + os.pathsep + env.get("PYTHONPATH", "")
+    return env
+
+
+@pytest.mark.contract
+def test_stdio_stdout_lines_are_json_after_structlog_emitted() -> None:
+    """Regression: structlog must not write to stdout; only JSON lines may appear."""
+    code = """
+import json
+import sys
+import structlog
+from nz_mcp.logging_config import configure_logging_for_stdio
+configure_logging_for_stdio()
+structlog.get_logger("x").info("evt", k="v")
+sys.stdout.write(json.dumps({"jsonrpc": "2.0", "id": 0, "result": {}}) + "\\n")
+"""
+    proc = subprocess.run(  # noqa: S603
+        [sys.executable, "-c", code],
+        check=False,
+        capture_output=True,
+        text=True,
+        cwd=_project_root(),
+        env=_env_for_subprocess(),
+    )
+    assert proc.returncode == 0, proc.stderr
+    for line in proc.stdout.splitlines():
+        if line.strip():
+            obj = json.loads(line)
+            assert obj.get("jsonrpc") == "2.0"

--- a/tests/unit/test_logging_config.py
+++ b/tests/unit/test_logging_config.py
@@ -1,0 +1,86 @@
+"""Tests for stdio-safe logging (issue #86)."""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+
+def _project_root() -> Path:
+    return Path(__file__).resolve().parents[2]
+
+
+def _env_for_subprocess() -> dict[str, str]:
+    env = os.environ.copy()
+    src = str(_project_root() / "src")
+    env["PYTHONPATH"] = src + os.pathsep + env.get("PYTHONPATH", "")
+    return env
+
+
+def _run_isolated(code: str) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(  # noqa: S603
+        [sys.executable, "-c", code],
+        check=False,
+        capture_output=True,
+        text=True,
+        cwd=_project_root(),
+        env=_env_for_subprocess(),
+    )
+
+
+def test_configure_logging_routes_root_handlers_to_stderr() -> None:
+    code = """
+import logging
+import sys
+from nz_mcp.logging_config import configure_logging_for_stdio
+configure_logging_for_stdio()
+root = logging.getLogger()
+streams = [h.stream for h in root.handlers if hasattr(h, "stream")]
+assert streams, "expected at least one stream handler on root"
+assert all(s is sys.stderr for s in streams), streams
+print("ok")
+"""
+    proc = _run_isolated(code)
+    assert proc.returncode == 0, proc.stderr
+    assert "ok" in proc.stdout
+
+
+def test_structlog_log_does_not_reach_stdout() -> None:
+    code = """
+import json
+import sys
+import structlog
+from nz_mcp.logging_config import configure_logging_for_stdio
+configure_logging_for_stdio()
+structlog.get_logger("x").info("evt", payload="data")
+sys.stdout.write(json.dumps({"jsonrpc": "2.0", "id": 1, "result": {}}) + "\\n")
+"""
+    proc = _run_isolated(code)
+    assert proc.returncode == 0, proc.stderr
+    lines = [ln for ln in proc.stdout.splitlines() if ln.strip()]
+    assert len(lines) == 1
+    assert json.loads(lines[0])["jsonrpc"] == "2.0"
+    assert "evt" in proc.stderr or "payload" in proc.stderr or proc.stderr.strip()
+
+
+def test_stdout_only_json_lines_after_structlog_subprocess() -> None:
+    """Each non-empty stdout line must parse as JSON (no structlog text on stdout)."""
+    code = """
+import json
+import sys
+import structlog
+from nz_mcp.logging_config import configure_logging_for_stdio
+configure_logging_for_stdio()
+structlog.get_logger("audit").info("clone_procedure_plan", source_database="DB")
+for i in range(2):
+    sys.stdout.write(json.dumps({"jsonrpc": "2.0", "id": i, "result": {}}) + "\\n")
+"""
+    proc = _run_isolated(code)
+    assert proc.returncode == 0, proc.stderr
+    for line in proc.stdout.splitlines():
+        if not line.strip():
+            continue
+        json.loads(line)


### PR DESCRIPTION
## ¿Qué cambia?
El transporte MCP por stdio exige que **solo** JSON-RPC válido vaya por ``stdout``. ``structlog`` (p. ej. en ``clone_procedure``) escribía por defecto en ``stdout`` y rompía el parseo en Claude Desktop. Se centraliza ``configure_logging_for_stdio()``: logging raíz y ``structlog`` hacia ``stderr``, ``logging.captureWarnings(True)``, y filtro de ``UserWarning`` ruidosos de ``sqlglot`` en ese arranque. Se invoca al entrar en ``run_stdio_server`` y en ``nz-mcp serve``.

## Issue relacionado
Closes #86

## Acción según AGENTS.md
- **Ruta (keywords)**: server, CLI, tests
- **Docs leídos**:
  - docs/standards/git-workflow.md
  - docs/standards/testing.md
- **Rol asumido**: Release-oriented backend (stdio MCP) + QA

## Archivos tocados
- ``src/nz_mcp/logging_config.py`` (nuevo)
- ``src/nz_mcp/server.py``, ``src/nz_mcp/cli.py``
- ``tests/unit/test_logging_config.py``, ``tests/contract/test_stdio_stdout_json_lines.py``
- ``CHANGELOG.md``

## Auditoría pre-merge — 7 dimensiones

### 1. Contrato y compatibilidad
- [x] Si toca tools: N/A
- [x] ``CHANGELOG.md`` (ES/EN) en Unreleased
- [x] Sin breaking change de API pública de tools

### 2. Seguridad
- [x] Sin credenciales en logs nuevos
- [x] No se relaja ``sql_guard``

### 3. Mantenibilidad
- [x] Alcance mínimo

### 4. Tests
- [x] ``pytest -m \"not integration\"`` local verde

### 5. Tipado y estilo
- [x] ruff + mypy

### 6. Documentación
- [x] CHANGELOG

### 7. Idioma y forma
- [x] Commits/PR en español; código/comentarios en inglés

## Validación humana requerida
- [ ] Sí
- [x] No

## Notas para el auditor
Subprocesos en tests usan ``PYTHONPATH=src`` para importar ``nz_mcp`` sin instalación editable.