### PR TITLE
fix(sql-guard): firma nzplsql y returns sin tamaño (issue 89)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,8 @@ Cada entrada se documenta en **español** y **english**.
 - EN: CLI command ``nz-mcp edit-profile`` to update mode/limits on an existing profile (``tomli-w`` dependency).
 
 ### Fixed
+- ES: ``nz_clone_procedure`` / ``sql_guard`` — la cabecera ``CREATE PROCEDURE`` acepta tipos parametrizados con paréntesis anidados (p. ej. ``VARCHAR(20)``, ``NUMERIC(10,2)``); patrón compartido en ``procedure_head_pattern``. ``RETURNS VARCHAR`` / ``CHARACTER VARYING`` sin tamaño en DDL de catálogo se normaliza con longitud por defecto (4000) y advertencia (issue #89).
+- EN: ``nz_clone_procedure`` / ``sql_guard`` — ``CREATE PROCEDURE`` header accepts nested-paren parameter types (e.g. ``VARCHAR(20)``, ``NUMERIC(10,2)``); shared pattern in ``procedure_head_pattern``. ``RETURNS VARCHAR`` / ``CHARACTER VARYING`` without length in catalog DDL are normalized with default length (4000) and a warning (issue #89).
 - ES: servidor MCP stdio — ``structlog`` y logging estándar se configuran hacia ``stderr`` al arrancar ``serve`` / ``run_stdio_server``, evitando que Claude Desktop falle al parsear JSON-RPC por texto no JSON en ``stdout`` (issue #86).
 - EN: MCP stdio server — ``structlog`` and stdlib logging are configured to ``stderr`` when starting ``serve`` / ``run_stdio_server``, preventing Claude Desktop JSON-RPC parse errors from non-JSON text on ``stdout`` (issue #86).
 - ES: ``nz_table_stats`` — ya no usa ``_V_STATISTIC.LASTUPDATETIMESTAMP`` (columna inexistente en NPS 11.2.x); ``stats_last_analyzed`` queda siempre ``null``.

--- a/docs/architecture/security-model.md
+++ b/docs/architecture/security-model.md
@@ -57,7 +57,7 @@
 
 #### Procedimientos `CREATE ... LANGUAGE NZPLSQL AS`
 
-`sqlglot` no clasifica cuerpos NZPLSQL reales (`DECLARE`, `BEGIN`/`END`, cursores, etc.). Para sentencias que contienen el marcador `LANGUAGE NZPLSQL AS`, el guard **no** intenta parsear el cuerpo: valida la cabecera con regex (firma `schema.procedimiento`, sin `;` en la cabecera) y los identificadores con las mismas reglas que el catálogo. El cuerpo se trata como **opaco**; no es texto libre arbitrario del LLM en los flujos soportados (p. ej. clonado desde DDL ya obtenido del catálogo del propio servidor). El riesgo de inyección se concentra en la cabecera; ahí se exige `admin` y se rechazan cabeceras malformadas o apiladas.
+`sqlglot` no clasifica cuerpos NZPLSQL reales (`DECLARE`, `BEGIN`/`END`, cursores, etc.). Para sentencias que contienen el marcador `LANGUAGE NZPLSQL AS`, el guard **no** intenta parsear el cuerpo: valida la cabecera con regex (firma `schema.procedimiento`, lista de parámetros con **paréntesis anidados de un nivel** para tipos como `VARCHAR(n)` / `NUMERIC(p,s)`, sin `;` en la cabecera) y los identificadores con las mismas reglas que el catálogo. El cuerpo se trata como **opaco**; no es texto libre arbitrario del LLM en los flujos soportados (p. ej. clonado desde DDL ya obtenido del catálogo del propio servidor). El riesgo de inyección se concentra en la cabecera; ahí se exige `admin` y se rechazan cabeceras malformadas o apiladas.
 
 #### ``DROP TABLE`` con ``IF EXISTS`` en sufijo (Netezza)
 

--- a/src/nz_mcp/catalog/clone.py
+++ b/src/nz_mcp/catalog/clone.py
@@ -17,6 +17,7 @@ from nz_mcp.config import Profile
 from nz_mcp.connection import open_connection
 from nz_mcp.errors import InvalidInputError, NetezzaError, ProcedureAlreadyExistsError
 from nz_mcp.logging_utils import sanitize
+from nz_mcp.procedure_head_pattern import PROCEDURE_PARAM_LIST_PATTERN
 from nz_mcp.sql_guard import StatementKind
 from nz_mcp.sql_guard import validate as guard_validate
 
@@ -24,6 +25,7 @@ _LOG = structlog.get_logger(__name__)
 _MARKER: Final[str] = "\nLANGUAGE NZPLSQL AS\n"
 _MAX_TRANSFORMS: Final[int] = 20
 _MIN_LINES_FOR_RETURNS: Final[int] = 2
+_DEFAULT_STRING_TYPE_LENGTH: Final[int] = 4000
 
 # Heuristic: ``OTHERDB..OBJECT`` cross-database references in procedure body.
 _CROSS_DB: Final[re.Pattern[str]] = re.compile(
@@ -56,7 +58,7 @@ def _parse_first_procedure_line(line: str) -> tuple[str, str, str]:
     m = re.match(
         r"^\s*CREATE\s+(?:OR\s+REPLACE\s+)?PROCEDURE\s+"
         r"(?P<sch>[A-Z][A-Z0-9_]*)\.(?P<proc>[A-Z][A-Z0-9_]*)"
-        r"(?P<sig>\([^)]*\))\s*$",
+        rf"(?P<sig>{PROCEDURE_PARAM_LIST_PATTERN})\s*$",
         line.strip(),
         re.I,
     )
@@ -89,6 +91,32 @@ def _extract_returns(head_block: str) -> str | None:
         if ln.strip().upper().startswith("RETURNS"):
             return ln.strip()
     return None
+
+
+def _normalize_returns_for_netezza(returns_line: str | None) -> tuple[str | None, list[str]]:
+    """Append default max length when catalog string types lack ``(n)`` (Netezza requires)."""
+    if returns_line is None:
+        return None, []
+    warnings: list[str] = []
+    stripped = returns_line.strip()
+    n = _DEFAULT_STRING_TYPE_LENGTH
+    if re.match(r"^RETURNS\s+VARCHAR\s*$", stripped, re.IGNORECASE):
+        warnings.append(
+            "RETURNS VARCHAR had no length in catalog DDL; "
+            f"appended default ({n}) for Netezza execution.",
+        )
+        return f"RETURNS VARCHAR({n})", warnings
+    if re.match(r"^RETURNS\s+CHARACTER\s+VARYING\s*$", stripped, re.IGNORECASE):
+        warnings.append(
+            f"RETURNS CHARACTER VARYING had no length in catalog DDL; appended default ({n}).",
+        )
+        return f"RETURNS CHARACTER VARYING({n})", warnings
+    if re.match(r"^RETURNS\s+CHAR\s+VARYING\s*$", stripped, re.IGNORECASE):
+        warnings.append(
+            f"RETURNS CHAR VARYING had no length in catalog DDL; appended default ({n}).",
+        )
+        return f"RETURNS CHAR VARYING({n})", warnings
+    return returns_line, []
 
 
 def _apply_transformations(
@@ -159,12 +187,13 @@ def _build_target_ddl(
     target_schema: str,
     target_procedure: str,
     replace_if_exists: bool,
-) -> str:
+) -> tuple[str, list[str]]:
     lines = head_block.strip().splitlines()
     if not lines:
         raise InvalidInputError(detail="Empty procedure header.")
     _sch, _proc, sig = _parse_first_procedure_line(lines[0])
     ret = _extract_returns(head_block)
+    ret, ret_warnings = _normalize_returns_for_netezza(ret)
     ts = validate_catalog_identifier(target_schema)
     tp = validate_catalog_identifier(target_procedure)
     kw = "CREATE OR REPLACE PROCEDURE" if replace_if_exists else "CREATE PROCEDURE"
@@ -172,7 +201,7 @@ def _build_target_ddl(
     if ret:
         new_head = f"{new_head}\n{ret}"
     wrapped = _wrap_nzplsql_body(body)
-    return f"{new_head}{_MARKER}{wrapped}"
+    return f"{new_head}{_MARKER}{wrapped}", ret_warnings
 
 
 def clone_procedure(
@@ -209,13 +238,14 @@ def clone_procedure(
     xw = _cross_db_warnings(body, tdb)
     warnings = tw + xw
 
-    target_ddl = _build_target_ddl(
+    target_ddl, ret_warnings = _build_target_ddl(
         head_block=head_block,
         body=body,
         target_schema=tsch,
         target_procedure=tproc,
         replace_if_exists=replace_if_exists,
     )
+    warnings = warnings + ret_warnings
 
     parsed = guard_validate(target_ddl, mode="admin")
     if parsed.kind is not StatementKind.CREATE:

--- a/src/nz_mcp/procedure_head_pattern.py
+++ b/src/nz_mcp/procedure_head_pattern.py
@@ -1,0 +1,9 @@
+"""Shared regex fragments for Netezza NZPLSQL ``CREATE PROCEDURE`` header validation."""
+
+from __future__ import annotations
+
+from typing import Final
+
+# Outer ``(...)`` parameter list: allows one level of nested parens (``VARCHAR(20)``,
+# ``NUMERIC(10,2)``). Deeper nesting is not matched end-to-end here by design.
+PROCEDURE_PARAM_LIST_PATTERN: Final[str] = r"\((?:[^()]|\([^()]*\))*\)"

--- a/src/nz_mcp/sql_guard.py
+++ b/src/nz_mcp/sql_guard.py
@@ -17,6 +17,7 @@ from sqlglot import expressions as exp
 from nz_mcp.catalog.identifier import validate_catalog_identifier
 from nz_mcp.config import PermissionMode
 from nz_mcp.errors import GuardRejectedError, InvalidInputError, PermissionDeniedError
+from nz_mcp.procedure_head_pattern import PROCEDURE_PARAM_LIST_PATTERN
 
 
 class StatementKind(StrEnum):
@@ -52,7 +53,7 @@ _NZPLSQL_MARKER: Final[re.Pattern[str]] = re.compile(
 _NZPLSQL_PROC_HEAD: Final[re.Pattern[str]] = re.compile(
     r"^\s*CREATE\s+(?:OR\s+REPLACE\s+)?PROCEDURE\s+"
     r"(?P<sch>[A-Za-z][A-Za-z0-9_]*)\s*\.\s*(?P<proc>[A-Za-z][A-Za-z0-9_]*)"
-    r"\s*\([^)]*\)"
+    rf"\s*{PROCEDURE_PARAM_LIST_PATTERN}"
     r"(?:\s+RETURNS\b[\s\S]*)?\s*$",
     re.IGNORECASE | re.DOTALL,
 )

--- a/tests/unit/test_catalog_clone.py
+++ b/tests/unit/test_catalog_clone.py
@@ -6,7 +6,12 @@ from typing import Any, Literal
 
 import pytest
 
-from nz_mcp.catalog.clone import _wrap_nzplsql_body, clone_procedure
+from nz_mcp.catalog.clone import (
+    _normalize_returns_for_netezza,
+    _parse_first_procedure_line,
+    _wrap_nzplsql_body,
+    clone_procedure,
+)
 from nz_mcp.config import Profile
 from nz_mcp.errors import InvalidInputError, NetezzaError, ProcedureAlreadyExistsError
 
@@ -69,6 +74,63 @@ def test_clone_dry_run_real_shaped_nzplsql_body(monkeypatch: pytest.MonkeyPatch)
     assert "DECLARE" in out["ddl_to_execute"]
     assert "BEGIN_PROC" in out["ddl_to_execute"]
     assert "END_PROC" in out["ddl_to_execute"]
+
+
+def test_parse_first_procedure_line_parametrized_types() -> None:
+    sch, proc, sig = _parse_first_procedure_line(
+        "CREATE OR REPLACE PROCEDURE DBO.P(CHARACTER(8))",
+    )
+    assert sch == "DBO"
+    assert proc == "P"
+    assert sig == "(CHARACTER(8))"
+    _a, _b, sig2 = _parse_first_procedure_line(
+        "CREATE PROCEDURE SCH.X(DATE, VARCHAR(20))",
+    )
+    assert sig2 == "(DATE, VARCHAR(20))"
+
+
+def test_normalize_returns_varchar_no_size_appends_max_length() -> None:
+    line, w = _normalize_returns_for_netezza("RETURNS VARCHAR")
+    assert line is not None
+    assert "VARCHAR(4000)" in line
+    assert any("4000" in x for x in w)
+    line2, w2 = _normalize_returns_for_netezza("RETURNS CHARACTER VARYING")
+    assert line2 is not None
+    assert "CHARACTER VARYING(4000)" in line2
+    assert w2
+
+
+def test_clone_dry_run_varchar_return_no_size_gets_default(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    ddl = (
+        "CREATE OR REPLACE PROCEDURE DBO.P(CHARACTER(8))\n"
+        "RETURNS VARCHAR\n"
+        "LANGUAGE NZPLSQL AS\n"
+        "BEGIN NULL; END;\n"
+    )
+    monkeypatch.setattr(
+        "nz_mcp.catalog.clone.get_procedure_ddl",
+        lambda *_a, **_k: ddl,
+    )
+    monkeypatch.setattr("nz_mcp.catalog.clone.list_procedures", lambda *_a, **_k: [])
+
+    out = clone_procedure(
+        _profile(),
+        source_database="DEV",
+        source_schema="DBO",
+        source_procedure="P",
+        source_signature=None,
+        target_database="DEV",
+        target_schema="DBO",
+        target_procedure="P2",
+        replace_if_exists=False,
+        transformations=None,
+        dry_run=True,
+        confirm=False,
+    )
+    assert "VARCHAR(4000)" in out["ddl_to_execute"]
+    assert any("catalog DDL" in m.lower() or "4000" in m for m in out["warnings"])
 
 
 def test_wrap_nzplsql_body_idempotent_and_adds_markers() -> None:

--- a/tests/unit/test_sql_guard.py
+++ b/tests/unit/test_sql_guard.py
@@ -121,6 +121,31 @@ END;
     assert parsed.kind is StatementKind.CREATE
 
 
+@pytest.mark.parametrize(
+    "sig",
+    [
+        "CHARACTER(8)",
+        "CHARACTER VARYING(100)",
+        "NUMERIC(10,2)",
+        "DATE, VARCHAR(20)",
+        "CHARACTER(10), NUMERIC(10,2), VARCHAR(50)",
+    ],
+)
+def test_validate_nzplsql_procedure_nested_param_types(sig: str) -> None:
+    sql = f"CREATE PROCEDURE DBO.P({sig})\nRETURNS INTEGER\nLANGUAGE NZPLSQL AS\nBEGIN NULL; END;\n"
+    parsed = validate(sql, mode="admin")
+    assert parsed.kind is StatementKind.CREATE
+
+
+def test_validate_nzplsql_procedure_rejects_triple_nested_param_list() -> None:
+    sql = (
+        "CREATE PROCEDURE DBO.P(((INT)))\nRETURNS INTEGER\nLANGUAGE NZPLSQL AS\nBEGIN NULL; END;\n"
+    )
+    with pytest.raises(GuardRejectedError) as exc:
+        validate(sql, mode="admin")
+    assert exc.value.code == "UNKNOWN_STATEMENT"
+
+
 def test_validate_procedure_with_loops() -> None:
     sql = """CREATE OR REPLACE PROCEDURE SCH.P()
 RETURNS INTEGER


### PR DESCRIPTION
## ¿Qué cambia?
El regex de cabecera ``CREATE PROCEDURE`` (``clone`` + ``sql_guard``) solo permitía ``(...)`` sin paréntesis internos, así que firmas reales con ``VARCHAR(20)``, ``NUMERIC(10,2)``, etc. fallaban. Se introduce un patrón compartido ``procedure_head_pattern`` con **un nivel** de anidación en la lista de parámetros.

Si el catálogo devuelve ``RETURNS VARCHAR`` o ``RETURNS CHARACTER VARYING`` **sin** ``(n)``, Netezza falla al ejecutar; se añade longitud por defecto (4000) y se emite **warning** en el dry_run de ``nz_clone_procedure``.

## Issue relacionado
Closes #89

## Acción según AGENTS.md
- **Ruta**: sql_guard, DDL/procedure, seguridad
- **Docs leídos**: ``docs/architecture/security-model.md``, ``docs/actions/modify-sql-guard.md``
- **Rol**: Security Engineer + Data Engineer

## Archivo sensible
- ``src/nz_mcp/sql_guard.py`` — se leyó ``security-model.md`` y ``modify-sql-guard.md``

## Auditoría pre-merge (resumen)
- [x] Contrato / tests / CHANGELOG
- [x] ``pytest -m \"not integration\"`` local verde
- [x] ruff + mypy

## Validación humana requerida
- [x] No