### PR TITLE
fix(server): silencia nzpy al nivel WARNING bajo stdio (issue 92)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ Cada entrada se documenta en **español** y **english**.
 ## [Unreleased]
 
 ### Changed
+- ES: ``configure_logging_for_stdio`` eleva el logger ``nzpy`` a ``WARNING`` bajo stdio para silenciar el DEBUG/INFO por paquete que rompe la UI de los clientes que renderizan en stderr (p.ej. la barra de progreso de ``nz-workbench kb-bootstrap``).
+- EN: ``configure_logging_for_stdio`` raises the ``nzpy`` logger to ``WARNING`` under stdio so the per-packet DEBUG/INFO noise no longer shreds client UIs that render on stderr (e.g. the ``nz-workbench kb-bootstrap`` progress bar).
 - ES: ``nz_insert`` — por defecto ``dry_run=true`` y ``confirm`` obligatorio para ejecutar (mismo patrón que update/delete).
 - EN: ``nz_insert`` — defaults to ``dry_run=true`` and requires ``confirm`` to execute (same pattern as update/delete).
 - ES: ``nz_create_table`` — por defecto ``dry_run=true``; para ejecutar en el servidor hace falta ``dry_run=false`` y ``confirm=true``. Salida alineada con otras tools DDL: ``ddl_to_execute``, ``executed``, ``duration_ms``.

--- a/src/nz_mcp/logging_config.py
+++ b/src/nz_mcp/logging_config.py
@@ -11,6 +11,11 @@ import structlog
 
 _state: dict[str, bool] = {"configured": False}
 
+# Third-party loggers that flood stderr with per-packet DEBUG/INFO noise when
+# left at default levels. Clients that wrap nz-mcp (e.g. nz-workbench) render
+# UI on stderr, so this noise breaks their output.
+_NOISY_LOGGERS: Final[tuple[str, ...]] = ("nzpy",)
+
 
 def configure_logging_for_stdio() -> None:
     """Route stdlib logging and structlog to stderr so stdout stays JSON-RPC only.
@@ -30,6 +35,9 @@ def configure_logging_for_stdio() -> None:
             format="%(asctime)s [%(levelname)s] %(name)s: %(message)s",
         )
     logging.captureWarnings(True)
+
+    for name in _NOISY_LOGGERS:
+        logging.getLogger(name).setLevel(logging.WARNING)
 
     warnings.filterwarnings(
         "ignore",

--- a/tests/unit/test_logging_config.py
+++ b/tests/unit/test_logging_config.py
@@ -84,3 +84,26 @@ for i in range(2):
         if not line.strip():
             continue
         json.loads(line)
+
+
+def test_nzpy_logger_is_silenced_to_warning() -> None:
+    """nzpy's per-packet DEBUG/INFO noise must not reach stderr under stdio.
+
+    Clients that wrap nz-mcp render UI on stderr (e.g. nz-workbench's
+    kb-bootstrap progress bar) — leaving nzpy at its default level shreds
+    that UI.
+    """
+    code = """
+import logging
+from nz_mcp.logging_config import configure_logging_for_stdio
+configure_logging_for_stdio()
+lvl = logging.getLogger("nzpy").getEffectiveLevel()
+assert lvl >= logging.WARNING, f"expected >=WARNING, got {lvl}"
+# Child loggers inherit the level.
+child = logging.getLogger("nzpy.Connection")
+assert child.getEffectiveLevel() >= logging.WARNING
+print("ok")
+"""
+    proc = _run_isolated(code)
+    assert proc.returncode == 0, proc.stderr
+    assert "ok" in proc.stdout


### PR DESCRIPTION
## ¿Qué cambia?

``configure_logging_for_stdio`` eleva el logger ``nzpy`` a ``WARNING`` bajo stdio. El DEBUG/INFO por paquete que emitía el driver contaminaba el stderr del subprocess y rompía la UI de clientes que renderizan ahí — caso concreto: la barra Rich de ``nz-workbench kb-bootstrap`` queda inservible.

## Issue relacionado

Closes #92

## Acción según AGENTS.md

- **Ruta (keywords)**: server, logging, stdio, nzpy, downstream clients
- **Docs leídos**:
  - ``AGENTS.md``
  - ``docs/standards/testing.md``
  - ``CHANGELOG.md``
- **Rol asumido**: Backend Developer (autor IA) + Tech Lead

## Archivos esperados (según el issue)

- ``src/nz_mcp/logging_config.py`` — añade tupla ``_NOISY_LOGGERS`` y loop ``setLevel(WARNING)``.
- ``tests/unit/test_logging_config.py`` — nuevo test en subprocess aislado.
- ``CHANGELOG.md`` — entrada bilingüe en ``### Changed``.

Sin archivos extra.

## Auditoría pre-merge — 7 dimensiones

### 1. Contrato y compatibilidad
- [x] Sin cambios en tools.
- [x] ``CHANGELOG.md`` con entrada bilingüe en ``Unreleased``.
- [x] Sin breaking change — solo baja verbosidad de un logger 3rd-party.

### 2. Seguridad
- [x] No toca SQL.
- [x] Sin SQL concatenado.
- [x] Sin credenciales.
- [x] No toca ``sql_guard.py`` ni ``auth.py``.

### 3. Mantenibilidad y diseño
- [x] Solo los 3 archivos esperados.
- [x] Sin abstracciones nuevas (``_NOISY_LOGGERS`` es la misma convención que ya usa nz-workbench).
- [x] Sin dependencias nuevas.
- [x] Función ``configure_logging_for_stdio`` sigue < 50 LoC; 0 args.
- [x] Una intención por PR: silenciar nzpy.
- [x] PR < 50 LoC totales.

### 4. Tests
- [x] Nuevo test verifica ``getEffectiveLevel() >= WARNING`` para ``nzpy`` y su child ``nzpy.Connection``.
- [x] ``pytest tests/unit -q`` → 488 passed local.
- [x] Coverage sin cambios relevantes (fix < 10 LoC).
- [x] Sin ``pytest.skip()`` ni ``xfail``.

### 5. Tipado y estilo
- [x] ``ruff check .`` + ``ruff format --check .`` limpios.
- [x] ``mypy src tests`` limpio (112 archivos).
- [x] Sin ``Any``.
- [x] Sin ``except Exception``.

### 6. Documentación
- [x] No cambia API pública.
- [x] ``CHANGELOG.md`` actualizado (ES + EN).
- [x] No requiere ADR (cambio operativo menor).
- [x] Sin mensajes nuevos.

### 7. Idioma y forma
- [x] Título en español, conventional commit.
- [x] Branch ``fix/92-silence-nzpy-stdio`` — regex OK.
- [x] Commit en español, conventional.
- [x] Código/comentarios nuevos en inglés.

## Validación humana requerida

- [x] Sí — explicar por qué: **excepción al patrón dual-IA.** Por pedido explícito del usuario ("aplica el código luego subimos el PR, para probarlo"), esta PR fue escrita end-to-end por Claude en lugar del flujo author=Codex / auditor=Claude. El usuario queda como única validación humana antes del merge y verificará empíricamente que la barra de ``nz-workbench kb-bootstrap`` ya no se rompe.

## Notas para el auditor

- La tupla ``_NOISY_LOGGERS`` queda disponible para futuras adiciones (``httpcore``, ``httpx``, etc.) sin refactor.
- Riesgo mínimo: si hiciera falta ver DEBUG de nzpy en troubleshooting, queda accesible via ``logging.getLogger("nzpy").setLevel(logging.DEBUG)`` tras ``configure_logging_for_stdio``.