### PR TITLE
fix(server): pasa logLevel=2 a nzpy.connect (issue 94)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ Cada entrada se documenta en **español** y **english**.
 ### Changed
 - ES: ``configure_logging_for_stdio`` eleva el logger ``nzpy`` a ``WARNING`` bajo stdio para silenciar el DEBUG/INFO por paquete que rompe la UI de los clientes que renderizan en stderr (p.ej. la barra de progreso de ``nz-workbench kb-bootstrap``).
 - EN: ``configure_logging_for_stdio`` raises the ``nzpy`` logger to ``WARNING`` under stdio so the per-packet DEBUG/INFO noise no longer shreds client UIs that render on stderr (e.g. the ``nz-workbench kb-bootstrap`` progress bar).
+- ES: ``open_connection`` pasa ``logLevel=2`` (WARNING en la convención de nzpy) a ``nzpy.connect``. nzpy hace ``setLevel(logLevel)`` sobre el logger hijo ``nzpy.Connection[<db>}]`` en cada conexión, bypasseando el nivel del padre; sin este flag el silenciado del logger padre no tenía efecto real.
+- EN: ``open_connection`` passes ``logLevel=2`` (WARNING in nzpy's convention) to ``nzpy.connect``. nzpy calls ``setLevel(logLevel)`` on the per-connection child logger ``nzpy.Connection[<db>}]``, bypassing parent-level filtering; without this flag the parent-logger silencing had no effect in practice.
 - ES: ``nz_insert`` — por defecto ``dry_run=true`` y ``confirm`` obligatorio para ejecutar (mismo patrón que update/delete).
 - EN: ``nz_insert`` — defaults to ``dry_run=true`` and requires ``confirm`` to execute (same pattern as update/delete).
 - ES: ``nz_create_table`` — por defecto ``dry_run=true``; para ejecutar en el servidor hace falta ``dry_run=false`` y ``confirm=true``. Salida alineada con otras tools DDL: ``ddl_to_execute``, ``executed``, ``duration_ms``.

--- a/src/nz_mcp/connection.py
+++ b/src/nz_mcp/connection.py
@@ -14,6 +14,12 @@ if TYPE_CHECKING:
 
 APPLICATION_NAME: Final[str] = "nz-mcp"
 
+# nzpy's per-Connection logger gets explicit setLevel in its __init__, bypassing
+# parent-logger filtering. ``logLevel=2`` maps to WARNING (0=DEBUG, 1=INFO, 2=WARNING
+# in nzpy's convention); anything lower floods stderr with per-packet traffic and
+# breaks client UIs that render on stderr.
+_NZPY_LOG_LEVEL_WARNING: Final[int] = 2
+
 
 def open_connection(profile: Profile, password: str) -> object:
     """Open a Netezza connection with bounded timeout and fixed app name."""
@@ -27,6 +33,7 @@ def open_connection(profile: Profile, password: str) -> object:
             timeout=profile.timeout_s_default,
             application_name=APPLICATION_NAME,
             securityLevel=1,
+            logLevel=_NZPY_LOG_LEVEL_WARNING,
         )
     except Exception as exc:  # noqa: BLE001, RUF100
         # nzpy may raise unchecked driver errors; we surface them as typed ConnectionError for MCP.

--- a/tests/unit/test_connection.py
+++ b/tests/unit/test_connection.py
@@ -44,6 +44,9 @@ def test_open_connection_calls_nzpy_with_expected_parameters(
     assert captured["timeout"] == 45
     assert captured["application_name"] == APPLICATION_NAME
     assert captured["securityLevel"] == 1
+    # Maps to WARNING inside nzpy; lower values flood stderr with per-packet DEBUG
+    # that shreds client UIs rendering on stderr (e.g. nz-workbench progress bar).
+    assert captured["logLevel"] == 2
 
 
 def test_open_connection_sanitizes_known_password_in_driver_detail(


### PR DESCRIPTION
## ¿Qué cambia?

``open_connection`` ahora pasa ``logLevel=2`` (WARNING en la convención de nzpy) a ``nzpy.connect``. El fix previo del #92 (silenciar el logger padre) **no tenía efecto real**: nzpy hace ``setLevel`` explícito sobre el logger hijo ``nzpy.Connection[<db>}]`` en cada conexión, cortando la propagación del padre. Verificado empíricamente: con ``logLevel=2`` la barra Rich de ``nz-workbench kb-bootstrap`` queda limpia.

## Issue relacionado

Closes #94

## Acción según AGENTS.md

- **Ruta (keywords)**: server, connection, nzpy, logging, downstream clients
- **Docs leídos**:
  - ``AGENTS.md``
  - ``docs/standards/testing.md``
  - ``CHANGELOG.md``
  - ``nzpy/core.py`` (source) para confirmar el mapeo ``logLevel=2 → WARNING``
- **Rol asumido**: Backend Developer (autor IA) + Tech Lead

## Archivos esperados (según el issue)

- ``src/nz_mcp/connection.py`` — añade ``logLevel=_NZPY_LOG_LEVEL_WARNING`` con constante nombrada.
- ``tests/unit/test_connection.py`` — extiende assert con ``captured[\"logLevel\"] == 2``.
- ``CHANGELOG.md`` — entrada bilingüe en ``### Changed``.

Sin archivos extra.

## Auditoría pre-merge — 7 dimensiones

### 1. Contrato y compatibilidad
- [x] Sin cambios en tools.
- [x] ``CHANGELOG.md`` con entrada bilingüe.
- [x] Sin breaking change — parámetro nuevo al driver, transparente para clientes MCP.

### 2. Seguridad
- [x] No toca SQL.
- [x] Sin SQL concatenado.
- [x] Sin credenciales.
- [x] No toca ``sql_guard.py`` ni ``auth.py``.

### 3. Mantenibilidad y diseño
- [x] Solo los 3 archivos esperados.
- [x] Sin abstracciones nuevas (una constante ``Final[int]`` con comentario explicando el mapeo).
- [x] Sin dependencias nuevas.
- [x] ``open_connection`` sigue < 50 LoC; 2 args.
- [x] Una intención por PR.
- [x] PR < 20 LoC netas.

### 4. Tests
- [x] Test existente ``test_open_connection_calls_nzpy_with_expected_parameters`` extendido con nuevo assert.
- [x] ``pytest -q`` verde local (7 passed en los archivos tocados; ``488 passed`` en la suite unit completa).
- [x] Coverage sin cambios relevantes.
- [x] Sin ``pytest.skip()`` / ``xfail``.

### 5. Tipado y estilo
- [x] ``ruff check .`` + ``ruff format --check .`` limpios.
- [x] ``mypy src tests`` limpio.
- [x] Sin ``Any``.
- [x] Sin ``except Exception`` nuevo.

### 6. Documentación
- [x] No cambia API pública.
- [x] ``CHANGELOG.md`` actualizado (ES + EN).
- [x] Sin ADR (cambio operativo menor, root cause documentado en el issue).
- [x] Comentario en el código explica por qué la constante vale 2.

### 7. Idioma y forma
- [x] Título en español, conventional commit.
- [x] Branch ``fix/94-nzpy-connect-loglevel`` — regex OK.
- [x] Commit en español, conventional.
- [x] Código/comentarios en inglés.

## Validación humana requerida

- [x] Sí — explicar por qué: **excepción al patrón dual-IA continuando el flujo del PR #93.** El usuario autorizó la iteración end-to-end por Claude porque el fix anterior falló en verificación empírica y quiso cerrar el loop rápido. Validación humana = el usuario corre ``kb-bootstrap`` tras el merge y confirma que la barra queda limpia.

## Notas para el auditor

- Verificación empírica previa al push: corrí ``nz-workbench kb-bootstrap --databases PROD_MODELOS --top 3`` con el fix aplicado. Las ~200 líneas ``[DEBUG] nzpy.Connection[...]`` que antes floodeaban la barra Rich desaparecieron. Los únicos logs restantes son: 1 ``event='nz_mcp_started'`` (nz-workbench), 3 ``[INFO] mcp.server.lowlevel.server: Processing request of type CallToolRequest`` (MCP SDK), y los ``kb_index_proc_start/done`` de nz-workbench (no vienen de nz-mcp).
- El silenciado del logger padre del PR #93 se mantiene como defensa adicional. Si un día nzpy emitiera desde un logger distinto a ``nzpy.Connection[...]``, seguirá estando cubierto.
- No hay path ``logLevel=DEBUG`` disponible hoy para troubleshooting remoto. Si hiciera falta, sería trivial agregarlo via env var (``NZ_MCP_NZPY_DEBUG=1``) en un issue aparte; por ahora YAGNI.