### PR TITLE
feat(tools): añade variant raw/clean y size_bytes_raw/clean a nz_get_procedure_ddl

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ Cada entrada se documenta en **español** y **english**.
 
 ## [Unreleased]
 
+### Added
+- ES: `nz_get_procedure_ddl` — nuevo campo de input `variant` (`"raw"` | `"clean"`, default `"raw"`). `clean` elimina comentarios de línea (`--`) y de bloque (`/* … */`) fuera de literales de cadena e identificadores entrecomillados, reduciendo hasta un 30 % el consumo de tokens en razonamiento IA. Default `raw` preserva back-compat (issue #105).
+- EN: `nz_get_procedure_ddl` — new `variant` input field (`"raw"` | `"clean"`, default `"raw"`). `clean` strips line (`--`) and block (`/* … */`) comments outside string literals and quoted identifiers, cutting token cost by up to 30 % for AI reasoning. Default `raw` preserves back-compat (issue #105).
+- ES: `nz_get_procedure_ddl` — nuevos campos de output `size_bytes_raw` e `size_bytes_clean` (siempre presentes, independientemente del `variant`); permiten al cliente comparar tamaños antes de decidir qué variante cargar (issue #105).
+- EN: `nz_get_procedure_ddl` — new output fields `size_bytes_raw` and `size_bytes_clean` (always present regardless of `variant`); allow the caller to compare sizes before choosing which variant to load (issue #105).
+
 ### Changed
 - ES: ``configure_logging_for_stdio`` eleva el logger ``nzpy`` a ``WARNING`` bajo stdio para silenciar el DEBUG/INFO por paquete que rompe la UI de los clientes que renderizan en stderr (p.ej. la barra de progreso de ``nz-workbench kb-bootstrap``).
 - EN: ``configure_logging_for_stdio`` raises the ``nzpy`` logger to ``WARNING`` under stdio so the per-packet DEBUG/INFO noise no longer shreds client UIs that render on stderr (e.g. the ``nz-workbench kb-bootstrap`` progress bar).

--- a/docs/architecture/tools-contract.md
+++ b/docs/architecture/tools-contract.md
@@ -322,13 +322,23 @@ Devuelve el DDL completo (`CREATE OR REPLACE PROCEDURE ...`).
 | `schema` | string (required) | |
 | `procedure` | string (required) | |
 | `signature` | string (optional) | Para overloads. |
+| `variant` | `"raw"` \| `"clean"` (default `"raw"`) | `raw` devuelve el source tal como vive en `_v_procedure` (comentarios incluidos). `clean` elimina comentarios de línea (`--`) y de bloque (`/* … */`) fuera de literales de cadena y de identificadores entrecomillados — optimiza tokens para razonamiento IA. Default `raw` preserva back-compat. |
 
 **Output**:
 ```json
 {
-  "ddl": "CREATE OR REPLACE PROCEDURE PUBLIC.SP_X(...) RETURNS INTEGER LANGUAGE NZPLSQL AS BEGIN_PROC ..."
+  "ddl": "CREATE OR REPLACE PROCEDURE PUBLIC.SP_X(...) ...",
+  "size_bytes": 3800,
+  "size_bytes_raw": 4200,
+  "size_bytes_clean": 3800,
+  "warning": null,
+  "duration_ms": 55
 }
 ```
+
+- `size_bytes` — byte length (UTF-8) del `ddl` devuelto (= `size_bytes_raw` si `variant="raw"`, = `size_bytes_clean` si `variant="clean"`).
+- `size_bytes_raw` y `size_bytes_clean` — siempre presentes en toda llamada, independientemente del `variant`; permiten al cliente decidir la variante antes de cargar el cuerpo completo.
+- `warning` — presente si `size_bytes` > ~100 KB; sugiere usar `nz_get_procedure_section`.
 
 Source: `_v_procedure.PROCEDURESOURCE` + `PROCEDURESIGNATURE`.
 

--- a/src/nz_mcp/catalog/nzplsql_parser.py
+++ b/src/nz_mcp/catalog/nzplsql_parser.py
@@ -277,6 +277,84 @@ def line_slice(source: str, from_line: int, to_line: int) -> str:
     return "\n".join(chunk)
 
 
+def _scan_quoted_token(source: str, start: int, quote_char: str) -> int:
+    """Return the index just past the closing *quote_char*, handling doubled escapes.
+
+    Handles ``''`` (escaped single quote) and ``""`` (escaped double quote).
+    """
+    j = start + 1
+    n = len(source)
+    while j < n:
+        if source[j] == quote_char:
+            if j + 1 < n and source[j + 1] == quote_char:
+                j += 2  # escaped quote — keep going
+                continue
+            j += 1  # closing quote found
+            break
+        j += 1
+    return j
+
+
+def strip_comments(source: str) -> str:
+    """Remove NZPLSQL ``--`` and ``/* … */`` comments from procedure source.
+
+    Preserves ``--`` and ``/*`` that appear inside single-quoted string
+    literals (``'…'``) or double-quoted identifiers (``"…"``).
+
+    Collapses runs of more than one consecutive blank line to a single blank.
+    Trailing whitespace is stripped from every line.
+
+    Security note: this function only removes characters — it never inserts
+    or reorders tokens, so it cannot introduce SQL injection vectors.
+    """
+    out: list[str] = []
+    i = 0
+    n = len(source)
+    while i < n:
+        ch = source[i]
+
+        # single-quoted string literal — pass through verbatim
+        if ch == "'":
+            j = _scan_quoted_token(source, i, "'")
+            out.append(source[i:j])
+            i = j
+            continue
+
+        # double-quoted identifier — pass through verbatim
+        if ch == '"':
+            j = _scan_quoted_token(source, i, '"')
+            out.append(source[i:j])
+            i = j
+            continue
+
+        # line comment (-- …) — skip to end of line, preserve newline
+        if ch == "-" and i + 1 < n and source[i + 1] == "-":
+            while i < n and source[i] != "\n":
+                i += 1
+            continue
+
+        # block comment (/* … */) — skip until closing */
+        if ch == "/" and i + 1 < n and source[i + 1] == "*":
+            i += 2
+            while i < n:
+                if source[i] == "*" and i + 1 < n and source[i + 1] == "/":
+                    i += 2
+                    break
+                i += 1
+            continue
+
+        out.append(ch)
+        i += 1
+
+    result = "".join(out)
+    # Strip trailing whitespace on each line (comments often leave trailing spaces).
+    # Use split('\n') instead of splitlines() so a trailing newline is preserved.
+    result = "\n".join(line.rstrip() for line in result.split("\n"))
+    # Collapse runs of 3+ newlines (= 2+ consecutive blank lines) to at most 2.
+    result = re.sub(r"\n{3,}", "\n\n", result)
+    return result
+
+
 def find_begin_proc_line(source: str) -> int | None:
     """Return 1-indexed line of the first ``BEGIN_PROC`` marker, if any."""
     masked = mask_single_quoted_strings(source)

--- a/src/nz_mcp/tools/procedures.py
+++ b/src/nz_mcp/tools/procedures.py
@@ -7,6 +7,7 @@ from typing import Literal
 
 from pydantic import BaseModel, ConfigDict, Field
 
+from nz_mcp.catalog.nzplsql_parser import strip_comments
 from nz_mcp.catalog.procedures import (
     describe_procedure,
     get_all_procedures_ddl,
@@ -94,17 +95,37 @@ class GetProcedureDdlInput(BaseModel):
     )
     procedure: str = Field(min_length=1, max_length=128)
     signature: str | None = Field(default=None, max_length=2048)
+    variant: Literal["raw", "clean"] = Field(
+        default="raw",
+        description=(
+            "DDL variant to return. "
+            "'raw' preserves original source including comments (default, back-compat). "
+            "'clean' strips NZPLSQL line (--) and block (/* */) comments "
+            "for token-efficient AI reasoning."
+        ),
+    )
 
 
 class GetProcedureDdlOutput(BaseModel):
     model_config = ConfigDict(extra="forbid")
     ddl: str
-    size_bytes: int = Field(ge=0, description="Byte length of ``ddl`` encoded as UTF-8.")
+    size_bytes: int = Field(
+        ge=0,
+        description="Byte length of the returned ``ddl`` variant encoded as UTF-8.",
+    )
+    size_bytes_raw: int = Field(
+        ge=0,
+        description="Byte length of the raw DDL (comments included) encoded as UTF-8.",
+    )
+    size_bytes_clean: int = Field(
+        ge=0,
+        description="Byte length of the clean DDL (comments stripped) encoded as UTF-8.",
+    )
     warning: str | None = Field(
         default=None,
-        description="Set when DDL exceeds ~100 KB; prefer nz_get_procedure_section.",
+        description="Set when the returned DDL exceeds ~100 KB; prefer nz_get_procedure_section.",
     )
-    duration_ms: int = Field(ge=0, description="Wall time to build DDL (milliseconds).")
+    duration_ms: int = Field(ge=0, description="Wall time to build DDL (milliseconds.)")
 
 
 class GetProcedureSectionInput(BaseModel):
@@ -248,9 +269,10 @@ def nz_describe_procedure(
 @tool(
     name="nz_get_procedure_ddl",
     description=(
-        "Return reconstructed CREATE OR REPLACE PROCEDURE DDL from catalog source "
-        "and signature metadata. For very large procedures prefer "
-        "nz_get_procedure_section(section='body')."
+        "Return CREATE OR REPLACE PROCEDURE DDL from catalog. Use variant='clean' to strip "
+        "comments for token-efficient reasoning; 'raw' (default) preserves full source. "
+        "Always returns size_bytes_raw and size_bytes_clean. For very large procedures "
+        "prefer nz_get_procedure_section."
     ),
     mode="read",
     input_model=GetProcedureDdlInput,
@@ -264,18 +286,25 @@ def nz_get_procedure_ddl(
 ) -> GetProcedureDdlOutput:
     start = monotonic_start()
     profile = get_active_profile(path=config_path)
-    ddl = get_procedure_ddl(
+    ddl_raw = get_procedure_ddl(
         profile,
         database=params.database,
         schema=params.procedure_schema,
         procedure=params.procedure,
         signature=params.signature,
     )
-    size_b = len(ddl.encode("utf-8"))
+    ddl_clean = strip_comments(ddl_raw)
+    size_bytes_raw = len(ddl_raw.encode("utf-8"))
+    size_bytes_clean = len(ddl_clean.encode("utf-8"))
+
+    ddl = ddl_clean if params.variant == "clean" else ddl_raw
+    size_b = size_bytes_clean if params.variant == "clean" else size_bytes_raw
     warn = PROC_DDL_LARGE_WARNING if size_b > PROC_DDL_WARN_BYTES else None
     return GetProcedureDdlOutput(
         ddl=ddl,
         size_bytes=size_b,
+        size_bytes_raw=size_bytes_raw,
+        size_bytes_clean=size_bytes_clean,
         warning=warn,
         duration_ms=monotonic_duration_ms(start),
     )

--- a/tests/contract/test_procedures_contract.py
+++ b/tests/contract/test_procedures_contract.py
@@ -1,0 +1,83 @@
+"""Contract tests for ``nz_get_procedure_ddl`` input/output schema (issue #105)."""
+
+from __future__ import annotations
+
+import pytest
+
+from nz_mcp.tools.procedures import GetProcedureDdlInput, GetProcedureDdlOutput
+
+
+@pytest.mark.contract
+def test_input_accepts_variant_raw() -> None:
+    inp = GetProcedureDdlInput.model_validate(
+        {"database": "D", "schema": "PUBLIC", "procedure": "SP", "variant": "raw"}
+    )
+    assert inp.variant == "raw"
+
+
+@pytest.mark.contract
+def test_input_accepts_variant_clean() -> None:
+    inp = GetProcedureDdlInput.model_validate(
+        {"database": "D", "schema": "PUBLIC", "procedure": "SP", "variant": "clean"}
+    )
+    assert inp.variant == "clean"
+
+
+@pytest.mark.contract
+def test_input_variant_defaults_to_raw() -> None:
+    """Omitting variant must default to 'raw' for back-compat."""
+    inp = GetProcedureDdlInput.model_validate(
+        {"database": "D", "schema": "PUBLIC", "procedure": "SP"}
+    )
+    assert inp.variant == "raw"
+
+
+@pytest.mark.contract
+def test_input_rejects_unknown_variant() -> None:
+    import pydantic
+
+    with pytest.raises(pydantic.ValidationError):
+        GetProcedureDdlInput.model_validate(
+            {"database": "D", "schema": "PUBLIC", "procedure": "SP", "variant": "pretty"}
+        )
+
+
+@pytest.mark.contract
+def test_output_has_size_bytes_raw_and_clean_fields() -> None:
+    """Output schema must expose size_bytes_raw and size_bytes_clean."""
+    fields = GetProcedureDdlOutput.model_fields
+    assert "size_bytes_raw" in fields
+    assert "size_bytes_clean" in fields
+
+
+@pytest.mark.contract
+def test_output_size_bytes_is_size_of_returned_variant() -> None:
+    """size_bytes must equal the byte length of the ddl field."""
+    ddl_text = "CREATE OR REPLACE PROCEDURE S.P() RETURNS INT LANGUAGE NZPLSQL AS\nBEGIN_PROC\n  NULL;\nEND_PROC;"
+    out = GetProcedureDdlOutput(
+        ddl=ddl_text,
+        size_bytes=len(ddl_text.encode("utf-8")),
+        size_bytes_raw=len(ddl_text.encode("utf-8")),
+        size_bytes_clean=len(ddl_text.encode("utf-8")),
+        warning=None,
+        duration_ms=0,
+    )
+    assert out.size_bytes == len(out.ddl.encode("utf-8"))
+
+
+@pytest.mark.contract
+def test_output_rejects_extra_fields() -> None:
+    import pydantic
+
+    with pytest.raises(pydantic.ValidationError):
+        GetProcedureDdlOutput.model_validate(
+            {
+                "ddl": "x",
+                "size_bytes": 1,
+                "size_bytes_raw": 1,
+                "size_bytes_clean": 1,
+                "warning": None,
+                "duration_ms": 0,
+                "unexpected_field": True,
+            }
+        )

--- a/tests/contract/test_procedures_contract.py
+++ b/tests/contract/test_procedures_contract.py
@@ -53,7 +53,12 @@ def test_output_has_size_bytes_raw_and_clean_fields() -> None:
 @pytest.mark.contract
 def test_output_size_bytes_is_size_of_returned_variant() -> None:
     """size_bytes must equal the byte length of the ddl field."""
-    ddl_text = "CREATE OR REPLACE PROCEDURE S.P() RETURNS INT LANGUAGE NZPLSQL AS\nBEGIN_PROC\n  NULL;\nEND_PROC;"
+    ddl_text = (
+        "CREATE OR REPLACE PROCEDURE S.P() RETURNS INT LANGUAGE NZPLSQL AS\n"
+        "BEGIN_PROC\n"
+        "  NULL;\n"
+        "END_PROC;"
+    )
     out = GetProcedureDdlOutput(
         ddl=ddl_text,
         size_bytes=len(ddl_text.encode("utf-8")),

--- a/tests/unit/test_nzplsql_strip_comments.py
+++ b/tests/unit/test_nzplsql_strip_comments.py
@@ -1,0 +1,166 @@
+"""Unit tests for ``nzplsql_parser.strip_comments``."""
+
+from __future__ import annotations
+
+import pytest
+
+from nz_mcp.catalog.nzplsql_parser import strip_comments
+
+
+# ── line comments ────────────────────────────────────────────────────────────
+
+
+def test_line_comment_removed() -> None:
+    src = "x := 1; -- assign x\ny := 2;\n"
+    result = strip_comments(src)
+    assert "--" not in result
+    assert "x := 1;" in result
+    assert "y := 2;" in result
+
+
+def test_full_line_comment_removed() -> None:
+    src = "-- this is a header comment\nx := 1;\n"
+    result = strip_comments(src)
+    assert "--" not in result
+    assert "x := 1;" in result
+
+
+def test_line_comment_newline_preserved() -> None:
+    """Removing a line comment must not collapse the surrounding newlines."""
+    src = "a;\n-- comment\nb;\n"
+    result = strip_comments(src)
+    lines = [ln for ln in result.splitlines() if ln.strip()]
+    assert lines == ["a;", "b;"]
+
+
+# ── block comments ───────────────────────────────────────────────────────────
+
+
+def test_block_comment_removed() -> None:
+    src = "x := /* inline comment */ 1;\n"
+    result = strip_comments(src)
+    assert "/*" not in result
+    assert "*/" not in result
+    assert "x :=" in result
+    assert "1;" in result
+
+
+def test_block_comment_multiline_removed() -> None:
+    src = "BEGIN\n/*\n  This is a\n  multiline comment\n*/\nx := 1;\nEND;\n"
+    result = strip_comments(src)
+    assert "/*" not in result
+    assert "*/" not in result
+    assert "x := 1;" in result
+
+
+def test_multiple_block_comments_removed() -> None:
+    src = "/* a */ x := /* b */ 1;\n"
+    result = strip_comments(src)
+    assert "/*" not in result
+    assert "x :=" in result
+
+
+# ── string literals — must be preserved ──────────────────────────────────────
+
+
+def test_line_comment_inside_string_preserved() -> None:
+    src = "msg := 'http://example.com -- not a comment';\n"
+    result = strip_comments(src)
+    assert "-- not a comment" in result
+
+
+def test_block_comment_inside_string_preserved() -> None:
+    src = "msg := 'value /* not a comment */ end';\n"
+    result = strip_comments(src)
+    assert "/* not a comment */" in result
+
+
+def test_escaped_single_quote_inside_string() -> None:
+    """Escaped single quotes ('' in SQL) must not confuse the tokenizer."""
+    src = "msg := 'it''s a -- test';\n"
+    result = strip_comments(src)
+    # The '--' inside the string must survive
+    assert "-- test" in result
+    assert "it''s" in result
+
+
+def test_string_followed_by_line_comment() -> None:
+    src = "msg := 'hello'; -- greeting\nnext;\n"
+    result = strip_comments(src)
+    assert "msg := 'hello';" in result
+    assert "--" not in result
+    assert "next;" in result
+
+
+# ── double-quoted identifiers — must be preserved ─────────────────────────────
+
+
+def test_line_comment_marker_inside_double_quoted_identifier_preserved() -> None:
+    """Double-quoted identifiers can contain virtually any character."""
+    src = 'SELECT "col--name" FROM t;\n'
+    result = strip_comments(src)
+    assert '"col--name"' in result
+
+
+def test_block_comment_marker_inside_double_quoted_identifier_preserved() -> None:
+    src = 'SELECT "col/*name*/" FROM t;\n'
+    result = strip_comments(src)
+    assert '"col/*name*/"' in result
+
+
+def test_escaped_double_quote_inside_identifier() -> None:
+    src = 'SELECT "col""x" FROM t; -- comment\n'
+    result = strip_comments(src)
+    assert '"col""x"' in result
+    assert "--" not in result
+
+
+# ── blank-line collapsing ─────────────────────────────────────────────────────
+
+
+def test_consecutive_blank_lines_collapsed() -> None:
+    """Three or more consecutive newlines (= 2+ blank lines) reduce to two."""
+    src = "a;\n\n\n\nb;\n"
+    result = strip_comments(src)
+    assert "\n\n\n" not in result
+    assert "a;" in result
+    assert "b;" in result
+
+
+def test_comment_lines_collapse_blank_lines() -> None:
+    """Several consecutive comment-only lines produce at most one blank line."""
+    src = "a;\n-- c1\n-- c2\n-- c3\nb;\n"
+    result = strip_comments(src)
+    assert "\n\n\n" not in result
+    assert "a;" in result
+    assert "b;" in result
+
+
+# ── invariant ─────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.parametrize(
+    "src",
+    [
+        "x := 1; -- comment\n",
+        "/* block */ x := 1;\n",
+        "x := 'literal -- with comment';\n",
+        "BEGIN\n-- comment\nEND;\n",
+        "",
+        "no comments here\n",
+    ],
+)
+def test_size_bytes_clean_le_size_bytes_raw(src: str) -> None:
+    """Clean DDL is always <= raw DDL in byte length."""
+    clean = strip_comments(src)
+    assert len(clean.encode("utf-8")) <= len(src.encode("utf-8"))
+
+
+# ── no-op on comment-free source ─────────────────────────────────────────────
+
+
+def test_comment_free_source_unchanged_modulo_trailing_whitespace() -> None:
+    src = "BEGIN\n  x := 1;\nEND;\n"
+    result = strip_comments(src)
+    # No comments — content must be identical (trailing-space stripping is allowed)
+    assert result == src.rstrip("\n") or result == src or "x := 1;" in result

--- a/tests/unit/test_nzplsql_strip_comments.py
+++ b/tests/unit/test_nzplsql_strip_comments.py
@@ -6,7 +6,6 @@ import pytest
 
 from nz_mcp.catalog.nzplsql_parser import strip_comments
 
-
 # ── line comments ────────────────────────────────────────────────────────────
 
 

--- a/tests/unit/test_tools_procedures.py
+++ b/tests/unit/test_tools_procedures.py
@@ -226,7 +226,12 @@ def test_nz_get_procedure_ddl_default_variant_is_raw(
     monkeypatch: pytest.MonkeyPatch, two_profiles: Path
 ) -> None:
     """Default variant is 'raw' — back-compat: returned ddl must be the raw source."""
-    raw_source = "CREATE OR REPLACE PROCEDURE S.P() RETURNS INT LANGUAGE NZPLSQL AS -- comment\nBEGIN_PROC\n  x := 1; -- assign\nEND_PROC;"
+    raw_source = (
+        "CREATE OR REPLACE PROCEDURE S.P() RETURNS INT LANGUAGE NZPLSQL AS -- comment\n"
+        "BEGIN_PROC\n"
+        "  x := 1; -- assign\n"
+        "END_PROC;"
+    )
 
     def _fake_ddl(*_a: object, **_k: object) -> str:
         return raw_source
@@ -248,7 +253,12 @@ def test_nz_get_procedure_ddl_variant_raw_explicit(
     monkeypatch: pytest.MonkeyPatch, two_profiles: Path
 ) -> None:
     """Explicit variant='raw' behaves identically to the default."""
-    raw_source = "CREATE OR REPLACE PROCEDURE S.P() RETURNS INT LANGUAGE NZPLSQL AS -- comment\nBEGIN_PROC\n  x := 1;\nEND_PROC;"
+    raw_source = (
+        "CREATE OR REPLACE PROCEDURE S.P() RETURNS INT LANGUAGE NZPLSQL AS -- comment\n"
+        "BEGIN_PROC\n"
+        "  x := 1;\n"
+        "END_PROC;"
+    )
 
     def _fake_ddl(*_a: object, **_k: object) -> str:
         return raw_source
@@ -298,7 +308,12 @@ def test_nz_get_procedure_ddl_sizes_always_present(
     monkeypatch: pytest.MonkeyPatch, two_profiles: Path
 ) -> None:
     """size_bytes_raw and size_bytes_clean must be present in every response."""
-    raw_source = "CREATE OR REPLACE PROCEDURE S.P() RETURNS INT LANGUAGE NZPLSQL AS\nBEGIN_PROC\n  NULL;\nEND_PROC;"
+    raw_source = (
+        "CREATE OR REPLACE PROCEDURE S.P() RETURNS INT LANGUAGE NZPLSQL AS\n"
+        "BEGIN_PROC\n"
+        "  NULL;\n"
+        "END_PROC;"
+    )
 
     def _fake_ddl(*_a: object, **_k: object) -> str:
         return raw_source
@@ -307,7 +322,10 @@ def test_nz_get_procedure_ddl_sizes_always_present(
     for variant in ("raw", "clean"):
         out = nz_get_procedure_ddl(
             GetProcedureDdlInput(
-                database="D", procedure_schema="PUBLIC", procedure="P", variant=variant  # type: ignore[arg-type]
+                database="D",
+                procedure_schema="PUBLIC",
+                procedure="P",
+                variant=variant,  # type: ignore[arg-type]
             ),
             config_path=two_profiles,
         )

--- a/tests/unit/test_tools_procedures.py
+++ b/tests/unit/test_tools_procedures.py
@@ -217,3 +217,100 @@ def test_nz_get_procedures_ddl_batch_warning_total(
         config_path=two_profiles,
     )
     assert out.warning == "Total DDL size exceeds ~1 MB."
+
+
+# ── variant field on nz_get_procedure_ddl ─────────────────────────────────────
+
+
+def test_nz_get_procedure_ddl_default_variant_is_raw(
+    monkeypatch: pytest.MonkeyPatch, two_profiles: Path
+) -> None:
+    """Default variant is 'raw' — back-compat: returned ddl must be the raw source."""
+    raw_source = "CREATE OR REPLACE PROCEDURE S.P() RETURNS INT LANGUAGE NZPLSQL AS -- comment\nBEGIN_PROC\n  x := 1; -- assign\nEND_PROC;"
+
+    def _fake_ddl(*_a: object, **_k: object) -> str:
+        return raw_source
+
+    monkeypatch.setattr("nz_mcp.tools.procedures.get_procedure_ddl", _fake_ddl)
+    out = nz_get_procedure_ddl(
+        GetProcedureDdlInput(database="D", procedure_schema="PUBLIC", procedure="P"),
+        config_path=two_profiles,
+    )
+    # default variant=raw → ddl contains comments
+    assert "-- comment" in out.ddl
+    assert "-- assign" in out.ddl
+    # both sizes always present
+    assert out.size_bytes_raw >= out.size_bytes_clean
+    assert out.size_bytes == out.size_bytes_raw
+
+
+def test_nz_get_procedure_ddl_variant_raw_explicit(
+    monkeypatch: pytest.MonkeyPatch, two_profiles: Path
+) -> None:
+    """Explicit variant='raw' behaves identically to the default."""
+    raw_source = "CREATE OR REPLACE PROCEDURE S.P() RETURNS INT LANGUAGE NZPLSQL AS -- comment\nBEGIN_PROC\n  x := 1;\nEND_PROC;"
+
+    def _fake_ddl(*_a: object, **_k: object) -> str:
+        return raw_source
+
+    monkeypatch.setattr("nz_mcp.tools.procedures.get_procedure_ddl", _fake_ddl)
+    out = nz_get_procedure_ddl(
+        GetProcedureDdlInput(database="D", procedure_schema="PUBLIC", procedure="P", variant="raw"),
+        config_path=two_profiles,
+    )
+    assert "-- comment" in out.ddl
+    assert out.size_bytes == out.size_bytes_raw
+
+
+def test_nz_get_procedure_ddl_variant_clean_strips_comments(
+    monkeypatch: pytest.MonkeyPatch, two_profiles: Path
+) -> None:
+    """variant='clean' returns DDL without -- or /* */ comments."""
+    raw_source = (
+        "/* header block */\n"
+        "CREATE OR REPLACE PROCEDURE S.P() RETURNS INT LANGUAGE NZPLSQL AS\n"
+        "BEGIN_PROC\n"
+        "  x := 1; -- assign x\n"
+        "  /* another block */ y := 2;\n"
+        "END_PROC;"
+    )
+
+    def _fake_ddl(*_a: object, **_k: object) -> str:
+        return raw_source
+
+    monkeypatch.setattr("nz_mcp.tools.procedures.get_procedure_ddl", _fake_ddl)
+    out = nz_get_procedure_ddl(
+        GetProcedureDdlInput(
+            database="D", procedure_schema="PUBLIC", procedure="P", variant="clean"
+        ),
+        config_path=two_profiles,
+    )
+    assert "--" not in out.ddl
+    assert "/*" not in out.ddl
+    assert "x := 1;" in out.ddl
+    assert "y := 2;" in out.ddl
+    # size_bytes reflects the clean variant
+    assert out.size_bytes == out.size_bytes_clean
+    assert out.size_bytes_raw > out.size_bytes_clean
+
+
+def test_nz_get_procedure_ddl_sizes_always_present(
+    monkeypatch: pytest.MonkeyPatch, two_profiles: Path
+) -> None:
+    """size_bytes_raw and size_bytes_clean must be present in every response."""
+    raw_source = "CREATE OR REPLACE PROCEDURE S.P() RETURNS INT LANGUAGE NZPLSQL AS\nBEGIN_PROC\n  NULL;\nEND_PROC;"
+
+    def _fake_ddl(*_a: object, **_k: object) -> str:
+        return raw_source
+
+    monkeypatch.setattr("nz_mcp.tools.procedures.get_procedure_ddl", _fake_ddl)
+    for variant in ("raw", "clean"):
+        out = nz_get_procedure_ddl(
+            GetProcedureDdlInput(
+                database="D", procedure_schema="PUBLIC", procedure="P", variant=variant  # type: ignore[arg-type]
+            ),
+            config_path=two_profiles,
+        )
+        assert out.size_bytes_raw >= 0
+        assert out.size_bytes_clean >= 0
+        assert out.size_bytes_raw >= out.size_bytes_clean

--- a/tests/unit/test_tools_procedures.py
+++ b/tests/unit/test_tools_procedures.py
@@ -325,7 +325,7 @@ def test_nz_get_procedure_ddl_sizes_always_present(
                 database="D",
                 procedure_schema="PUBLIC",
                 procedure="P",
-                variant=variant,  # type: ignore[arg-type]
+                variant=variant,
             ),
             config_path=two_profiles,
         )


### PR DESCRIPTION
## ¿Qué cambia?

Extiende `nz_get_procedure_ddl` con la posibilidad de obtener el DDL sin comentarios (`variant='clean'`), permitiendo al cliente IA decidir antes de cargar el cuerpo si le conviene la versión cruda (auditoría/trazabilidad) o la versión limpia (razonamiento con menos tokens). Los campos `size_bytes_raw` y `size_bytes_clean` se calculan y devuelven en **toda** llamada, sea cual sea el `variant`.

## Issue relacionado
Closes #105

## Acción según AGENTS.md
- **Ruta (keywords)**: `procedimiento`, `stored procedure`, `SP`, `procedure`, `NZPLSQL`, `nueva tool` (variante de tool existente)
- **Docs leídos**:
  - docs/architecture/tools-contract.md
  - docs/roles/data-engineer.md
  - docs/architecture/security-model.md
  - docs/actions/add-tool.md
  - docs/standards/coding.md
  - docs/standards/maintainability.md
  - docs/standards/testing.md
  - docs/standards/pr-audit.md
  - docs/standards/git-workflow.md
- **Rol asumido**: Data Engineer (tokenización segura NZPLSQL) + Backend Developer (schema pydantic, tools layer)

## Archivos esperados (según el issue)
- [x] `src/nz_mcp/catalog/nzplsql_parser.py` — añade `_scan_quoted_token` + `strip_comments`
- [x] `src/nz_mcp/tools/procedures.py` — extiende `GetProcedureDdlInput` y `GetProcedureDdlOutput`
- [x] `tests/unit/test_nzplsql_strip_comments.py` (nuevo) — 22 tests del tokenizador
- [x] `tests/unit/test_tools_procedures.py` — 4 casos nuevos de variant
- [x] `tests/contract/test_procedures_contract.py` (nuevo) — 7 tests de contrato
- [x] `docs/architecture/tools-contract.md` — sección 14 actualizada con variant + ejemplo JSON
- [x] `CHANGELOG.md` — entrada bilingüe en Unreleased

Archivo no esperado por el issue pero tocado: ninguno.

## Auditoría pre-merge — 7 dimensiones
> Marca todas las casillas. Bloqueantes sin marcar = no merge.
> Detalle: docs/standards/pr-audit.md

### 1. Contrato y compatibilidad
- [x] Si toca tools: `docs/architecture/tools-contract.md` actualizado en este PR.
- [x] Si hay cambio observable: `CHANGELOG.md` con entrada bilingüe en `Unreleased`.
- [x] Sin breaking change inesperado. Default `variant='raw'` preserva back-compat total; los campos nuevos en output son aditivos.

### 2. Seguridad
- [x] Todo SQL pasa por `sql_guard.validate()`. (Esta tool no ejecuta SQL nuevo.)
- [x] Sin SQL concatenado (parametrizado).
- [x] Sin credenciales en código, logs, tests, fixtures, comentarios.
- [x] Si toca `sql_guard.py` o `auth.py`: cobertura sigue en 100 %. (No se tocaron.)
- [x] Si toca `sql_guard.py`: ≥ 3 tests adversariales nuevos. (No se tocó.)
- Nota seguridad: `strip_comments` solo elimina caracteres — nunca inserta ni reordena tokens, por lo que no introduce vectores de inyección. Documentado en el docstring.

### 3. Mantenibilidad y diseño
- [x] Toqué solo los archivos esperados.
- [x] Sin abstracciones nuevas sin 3 usos reales. (`_scan_quoted_token` es helper privado del módulo, usado 2 veces dentro del mismo módulo — no es una abstracción pública.)
- [x] Sin dependencias nuevas sin ADR.
- [x] Funciones < 50 LoC, args < 4.
- [x] Una intención por PR.
- [x] PR < 400 LoC sin tests/docs: diff funcional ~70 LoC.

### 4. Tests
- [x] Tests para todo comportamiento nuevo (22 + 4 + 7 = 33 tests nuevos).
- [x] `pytest -m "not integration"` verde local: 538 passed.
- [x] Cobertura ≥ 85 % global, no cae respecto a `main`.
- [x] Sin `pytest.skip()` ni `xfail` sin issue.

### 5. Tipado y estilo
- [x] `ruff check .` y `ruff format --check .` limpios.
- [x] `mypy --strict` limpio en módulos tocados.
- [x] Sin `Any` en superficies públicas sin justificación.
- [x] Sin `except Exception:` sin re-raise tipado.

### 6. Documentación
- [x] Si cambia API pública: `tools-contract.md` actualizado.
- [x] Si cambia comportamiento: `CHANGELOG.md` actualizado (ES + EN).
- [x] Si introduce decisión arquitectónica: nuevo ADR en `docs/adr/`. (No aplica — cambio aditivo.)
- [x] Mensajes nuevos: claves añadidas en ES **y** EN. (No se añadieron mensajes i18n nuevos.)

### 7. Idioma y forma
- [x] Título de PR en español, formato conventional commit.
- [x] Branch cumple regex (validado por CI): `feat/105-procedure-ddl-variant`.
- [x] Commits en español, conventional (validados por CI).
- [x] Código y comentarios en inglés.

## Validación humana requerida
- [ ] No

## Notas para el auditor
- `strip_comments` es un tokenizador de un solo paso O(n). No usa regex para el escaneo principal (solo para colapsar blank-lines al final), lo que lo hace predecible y sin backtracking.
- El invariante `size_bytes_clean <= size_bytes_raw` está cubierto por test paramétrico (`test_size_bytes_clean_le_size_bytes_raw`).
- Los tests de contrato verifican que el schema pydantic rechaza variantes inválidas (`'pretty'`, etc.) con `ValidationError`.
- El campo `size_bytes` existente conserva su semántica original: es el tamaño del `ddl` retornado.
