### PR TITLE
feat(tools): implementa nz_get_procedure_size

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ Cada entrada se documenta en **español** y **english**.
 ## [Unreleased]
 
 ### Added
+- ES: tool `nz_get_procedure_size` — permite obtener las métricas de tamaño (líneas y bytes, en variantes `raw` y `clean`) y detectar secciones lógicas de un SP sin retornar su cuerpo completo, ideal para token budgeting previo (issue #106).
+- EN: `nz_get_procedure_size` tool — returns size metrics (lines and bytes, in `raw` and `clean` variants) and detects logical sections of an SP without fetching its full body, ideal for token budgeting before loading DDL (issue #106).
 - ES: `nz_get_procedure_ddl` — nuevo campo de input `variant` (`"raw"` | `"clean"`, default `"raw"`). `clean` elimina comentarios de línea (`--`) y de bloque (`/* … */`) fuera de literales de cadena e identificadores entrecomillados, reduciendo hasta un 30 % el consumo de tokens en razonamiento IA. Default `raw` preserva back-compat (issue #105).
 - EN: `nz_get_procedure_ddl` — new `variant` input field (`"raw"` | `"clean"`, default `"raw"`). `clean` strips line (`--`) and block (`/* … */`) comments outside string literals and quoted identifiers, cutting token cost by up to 30 % for AI reasoning. Default `raw` preserves back-compat (issue #105).
 - ES: `nz_get_procedure_ddl` — nuevos campos de output `size_bytes_raw` e `size_bytes_clean` (siempre presentes, independientemente del `variant`); permiten al cliente comparar tamaños antes de decidir qué variante cargar (issue #105).

--- a/docs/adr/0010-tool-procedure-size.md
+++ b/docs/adr/0010-tool-procedure-size.md
@@ -1,0 +1,31 @@
+# 10. Separación de Responsabilidad de Tamaños en Tool de Procedimientos
+
+Date: 2026-05-06
+
+## Status
+
+Accepted
+
+## Context
+
+Con la introducción de la variante de DDL (raw vs. clean) en el Issue #105, se expusieron los campos `size_bytes_raw` y `size_bytes_clean` dentro del output de `nz_get_procedure_ddl`. Esto soluciona el problema de conocer el tamaño *una vez que se ha descargado* el DDL, pero no resuelve el problema de prespuesto de tokens por adelantado: si un Agente AI quiere saber cuánto "pesa" un Stored Procedure (SP) en Netezza antes de decidir leerlo completo o por secciones, necesita una herramienta de metadatos rápidos.
+
+Podríamos haber expandido la herramienta existente `nz_describe_procedure`, pero se presentaba un conflicto de responsabilidades:
+1. `nz_describe_procedure`: Describe la firma, argumentos, tipo y semántica del procedimiento.
+2. Sizing (`size_bytes_clean`, `lines_raw`): Son métricas puramente utilitarias para el motor LLM orientadas al manejo de su *context window*.
+
+## Decision
+
+Crear una nueva herramienta independiente llamada `nz_get_procedure_size`.
+
+1. **Responsabilidad Única:** Esta herramienta servirá exclusivamente para devolver métricas de tamaño (`lines`, `size_bytes`) tanto para la versión cruda como limpia del DDL, junto con las secciones detectadas.
+2. **Exclusión de DDL:** La herramienta **no** devolverá fragmentos del cuerpo del procedimiento (ni preview, ni cabecera).
+3. **Reutilización:** Se apoyará en los mismos helpers internos (ej. `strip_comments`, `parse_sections`) y hará la misma consulta base a `_v_procedure` que hace `nz_get_procedure_ddl`, evitando introducir carga de mantenimiento en nuevas queries SQL.
+
+## Consequences
+
+- **Positivas:** 
+  - Los agentes LLM pueden muestrear SPs masivos (e.g. >100 KB) por fracciones de segundo y de tokens, para luego decidir si usan `nz_get_procedure_section`.
+  - Mantenemos la interfaz de `nz_describe_procedure` limpia y enfocada en metadatos del dominio de BD (argumentos, retornos).
+- **Negativas:** 
+  - Incremento marginal en el número de tools registradas (aumento en el context prompt base del agente de la descripción de la tool).

--- a/docs/architecture/tools-contract.md
+++ b/docs/architecture/tools-contract.md
@@ -312,7 +312,34 @@ Metadata de un SP sin devolver el cuerpo completo.
 
 ---
 
-#### 14. `nz_get_procedure_ddl`
+#### 14. `nz_get_procedure_size`
+
+Extrae las métricas de tamaño (bytes y líneas, en sus variantes `raw` y `clean`) y detecta las secciones lógicas de un SP sin retornar su cuerpo completo. Ideal para token budgeting previo a descargar DDLs gigantes.
+
+| Input | Tipo | Descripción |
+|---|---|---|
+| `database` | string (required) | |
+| `schema` | string (required) | |
+| `procedure` | string (required) | |
+| `signature` | string (optional) | |
+
+**Output**:
+```json
+{
+  "name": "SP_LOAD_CUSTOMERS",
+  "signature": "SP_LOAD_CUSTOMERS(VARCHAR)",
+  "size_bytes_raw": 4200,
+  "size_bytes_clean": 3800,
+  "lines_raw": 247,
+  "lines_clean": 210,
+  "sections_detected": ["header", "declare", "body", "exception"],
+  "duration_ms": 15
+}
+```
+
+---
+
+#### 15. `nz_get_procedure_ddl`
 
 Devuelve el DDL completo (`CREATE OR REPLACE PROCEDURE ...`).
 
@@ -344,7 +371,7 @@ Source: `_v_procedure.PROCEDURESOURCE` + `PROCEDURESIGNATURE`.
 
 ---
 
-#### 15. `nz_get_procedure_section`
+#### 16. `nz_get_procedure_section`
 
 Extrae una sección específica de un SP (útil para evitar gastar tokens en SPs largos).
 
@@ -373,7 +400,7 @@ Implementación: parser ligero NZPLSQL en `catalog/procedures.py` (basado en mar
 
 ---
 
-#### 16. `nz_get_procedures_ddl_batch`
+#### 17. `nz_get_procedures_ddl_batch`
 
 Obtiene los DDL completos de todos los procedimientos almacenados de un schema en un solo paso. Útil para indexación masiva sin ejecutar cientos de queries individuales.
 
@@ -413,7 +440,7 @@ Implementación: usa una sola query al catálogo `_V_PROCEDURE` por schema. Emit
 
 > Todas requieren `NZ_ALLOW_WRITE=true` implícito por `mode: write` o superior en el perfil.
 
-#### 17. `nz_insert`
+#### 18. `nz_insert`
 
 | Input | Tipo | Descripción |
 |---|---|---|
@@ -435,7 +462,7 @@ Implementación: `INSERT INTO ... VALUES (...)` parametrizado. **Prohibido** con
 
 ---
 
-#### 18. `nz_update`
+#### 19. `nz_update`
 
 | Input | Tipo | Descripción |
 |---|---|---|
@@ -455,7 +482,7 @@ Implementación: `INSERT INTO ... VALUES (...)` parametrizado. **Prohibido** con
 
 ---
 
-#### 19. `nz_delete`
+#### 20. `nz_delete`
 
 Mismo patrón que `nz_update` con `where` obligatorio, `dry_run` default `true`.
 
@@ -469,7 +496,7 @@ Si `dry_run=false` sin `confirm=true` → código estable `CONFIRM_REQUIRED`.
 
 ### 🔴 DDL (`mode: admin`)
 
-#### 20. `nz_create_table`
+#### 21. `nz_create_table`
 
 | Input | Tipo | Descripción |
 |---|---|---|
@@ -491,7 +518,7 @@ Si `dry_run=false` sin `confirm=true` → código estable `CONFIRM_REQUIRED`.
 
 ---
 
-#### 21. `nz_truncate`
+#### 22. `nz_truncate`
 
 | Input | Tipo | Descripción |
 |---|---|---|
@@ -504,7 +531,7 @@ Si `dry_run=false` sin `confirm=true` → código estable `CONFIRM_REQUIRED`.
 
 ---
 
-#### 22. `nz_drop_table`
+#### 23. `nz_drop_table`
 
 | Input | Tipo | Descripción |
 |---|---|---|
@@ -518,7 +545,7 @@ Si `dry_run=false` sin `confirm=true` → código estable `CONFIRM_REQUIRED`.
 
 ---
 
-#### 23. `nz_clone_procedure`
+#### 24. `nz_clone_procedure`
 
 Clona un procedimiento almacenado de un origen a un destino (otro database/schema o renombrado).
 
@@ -556,7 +583,7 @@ Clona un procedimiento almacenado de un origen a un destino (otro database/schem
 
 ### ⚪ Sesión
 
-#### 24. `nz_current_profile`
+#### 25. `nz_current_profile`
 
 Sin inputs.
 
@@ -576,7 +603,7 @@ No incluye password ni secretos.
 
 ---
 
-#### 25. `nz_switch_profile`
+#### 26. `nz_switch_profile`
 
 | Input | Tipo | Descripción |
 |---|---|---|
@@ -590,7 +617,7 @@ No incluye password ni secretos.
 
 ---
 
-#### 26. `nz_export_ddl`
+#### 27. `nz_export_ddl`
 
 Unifica la obtención de DDL de **tabla**, **vista** o **procedimiento** y lo devuelve como **resultado MCP nativo**: bloque **resource** embebido (`mimeType: text/sql`, URI estable `nz-mcp://ddl/...`) más un bloque **text** con resumen. Pensado para clientes que muestran tarjeta de recurso / copia (p. ej. Claude Desktop). Delega en la misma lógica de catálogo que `nz_get_*_ddl`.
 
@@ -609,7 +636,7 @@ Unifica la obtención de DDL de **tabla**, **vista** o **procedimiento** y lo de
 
 ---
 
-#### 27. `nz_insert_select`
+#### 28. `nz_insert_select`
 
 `INSERT INTO schema.target [(columns)] SELECT ...` — copia masiva o multi-fila vía `UNION ALL`. El sub-`select_sql` se valida con `sql_guard` en modo `write` (solo `SELECT`); los literales van en el texto del SELECT (no parametrizados).
 
@@ -630,7 +657,7 @@ Unifica la obtención de DDL de **tabla**, **vista** o **procedimiento** y lo de
 
 ---
 
-#### 28. `nz_create_table_as`
+#### 29. `nz_create_table_as`
 
 `CREATE TABLE schema.target AS SELECT ...` con `DISTRIBUTE ON` / `ORGANIZE ON` (modo `admin`). Rechaza si el destino ya existe (catálogo). El `select_sql` se valida como `SELECT`; el núcleo `CREATE TABLE ... AS` se valida con `sql_guard`; los sufijos Netezza se añaden como plantillas con identificadores validados (igual que `nz_create_table`).
 

--- a/src/nz_mcp/catalog/procedures.py
+++ b/src/nz_mcp/catalog/procedures.py
@@ -13,6 +13,7 @@ from nz_mcp.catalog.nzplsql_parser import (
     header_content,
     line_slice,
     parse_sections,
+    strip_comments,
 )
 from nz_mcp.catalog.resolver import resolve_query
 from nz_mcp.catalog.row_shape import is_sequence_row
@@ -149,6 +150,42 @@ def get_procedure_ddl(
     rows = _fetch_procedure_rows(profile, database, schema, procedure)
     row = _pick_procedure_row(rows, signature, procedure)
     return _build_procedure_ddl(schema, row)
+
+
+def get_procedure_size(
+    profile: Profile,
+    database: str,
+    schema: str,
+    procedure: str,
+    signature: str | None = None,
+) -> dict[str, Any]:
+    """Return procedure size and line metrics without returning the DDL body."""
+    rows = _fetch_procedure_rows(profile, database, schema, procedure)
+    row = _pick_procedure_row(rows, signature, procedure)
+
+    raw_ddl = _build_procedure_ddl(schema, row)
+    clean_ddl = strip_comments(raw_ddl)
+
+    source = _ddl_get(row, "PROCEDURESOURCE")
+    sections = parse_sections(source)
+
+    detected: list[str] = []
+    for key in ("header", "declare", "body", "exception"):
+        if key in sections:
+            detected.append(key)
+
+    name = _ddl_get(row, "PROCEDURE").strip()
+    sig = _ddl_get(row, "PROCEDURESIGNATURE").strip()
+
+    return {
+        "name": name,
+        "signature": sig,
+        "size_bytes_raw": len(raw_ddl.encode("utf-8")),
+        "size_bytes_clean": len(clean_ddl.encode("utf-8")),
+        "lines_raw": 0 if not raw_ddl else len(raw_ddl.splitlines()),
+        "lines_clean": 0 if not clean_ddl else len(clean_ddl.splitlines()),
+        "sections_detected": detected,
+    }
 
 
 def get_procedure_section(

--- a/src/nz_mcp/tools/procedures.py
+++ b/src/nz_mcp/tools/procedures.py
@@ -13,6 +13,7 @@ from nz_mcp.catalog.procedures import (
     get_all_procedures_ddl,
     get_procedure_ddl,
     get_procedure_section,
+    get_procedure_size,
     list_procedures,
 )
 from nz_mcp.config import get_active_profile
@@ -126,6 +127,30 @@ class GetProcedureDdlOutput(BaseModel):
         description="Set when the returned DDL exceeds ~100 KB; prefer nz_get_procedure_section.",
     )
     duration_ms: int = Field(ge=0, description="Wall time to build DDL (milliseconds.)")
+
+
+class GetProcedureSizeInput(BaseModel):
+    model_config = ConfigDict(extra="forbid", populate_by_name=True)
+    database: str = Field(min_length=1, max_length=128)
+    procedure_schema: str = Field(
+        alias="schema",
+        min_length=1,
+        max_length=128,
+    )
+    procedure: str = Field(min_length=1, max_length=128)
+    signature: str | None = Field(default=None, max_length=2048)
+
+
+class GetProcedureSizeOutput(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+    name: str
+    signature: str
+    size_bytes_raw: int = Field(ge=0)
+    size_bytes_clean: int = Field(ge=0)
+    lines_raw: int = Field(ge=0)
+    lines_clean: int = Field(ge=0)
+    sections_detected: list[str]
+    duration_ms: int = Field(ge=0, description="Wall time to calculate size (milliseconds).")
 
 
 class GetProcedureSectionInput(BaseModel):
@@ -306,6 +331,44 @@ def nz_get_procedure_ddl(
         size_bytes_raw=size_bytes_raw,
         size_bytes_clean=size_bytes_clean,
         warning=warn,
+        duration_ms=monotonic_duration_ms(start),
+    )
+
+
+@tool(
+    name="nz_get_procedure_size",
+    description=(
+        "Return the byte size, line counts (raw and clean variants), and detected sections "
+        "of a procedure without fetching its full body text. Use this for token budgeting "
+        "before deciding whether to fetch the full procedure or fetch it by section."
+    ),
+    mode="read",
+    input_model=GetProcedureSizeInput,
+    output_model=GetProcedureSizeOutput,
+    annotations={"readOnlyHint": True, "idempotentHint": True, "openWorldHint": False},
+)
+def nz_get_procedure_size(
+    params: GetProcedureSizeInput,
+    *,
+    config_path: Path | None = None,
+) -> GetProcedureSizeOutput:
+    start = monotonic_start()
+    profile = get_active_profile(path=config_path)
+    result = get_procedure_size(
+        profile,
+        database=params.database,
+        schema=params.procedure_schema,
+        procedure=params.procedure,
+        signature=params.signature,
+    )
+    return GetProcedureSizeOutput(
+        name=result["name"],
+        signature=result["signature"],
+        size_bytes_raw=result["size_bytes_raw"],
+        size_bytes_clean=result["size_bytes_clean"],
+        lines_raw=result["lines_raw"],
+        lines_clean=result["lines_clean"],
+        sections_detected=result["sections_detected"],
         duration_ms=monotonic_duration_ms(start),
     )
 

--- a/tests/contract/test_procedures_contract.py
+++ b/tests/contract/test_procedures_contract.py
@@ -4,7 +4,12 @@ from __future__ import annotations
 
 import pytest
 
-from nz_mcp.tools.procedures import GetProcedureDdlInput, GetProcedureDdlOutput
+from nz_mcp.tools.procedures import (
+    GetProcedureDdlInput,
+    GetProcedureDdlOutput,
+    GetProcedureSizeInput,
+    GetProcedureSizeOutput,
+)
 
 
 @pytest.mark.contract
@@ -82,6 +87,55 @@ def test_output_rejects_extra_fields() -> None:
                 "size_bytes_raw": 1,
                 "size_bytes_clean": 1,
                 "warning": None,
+                "duration_ms": 0,
+                "unexpected_field": True,
+            }
+        )
+
+
+# ── nz_get_procedure_size ─────────────────────────────────────────────────────
+
+
+@pytest.mark.contract
+def test_size_input_accepts_schema_alias() -> None:
+    inp = GetProcedureSizeInput.model_validate(
+        {"database": "D", "schema": "PUBLIC", "procedure": "SP"}
+    )
+    assert inp.procedure_schema == "PUBLIC"
+
+
+@pytest.mark.contract
+def test_size_output_has_required_fields() -> None:
+    out = GetProcedureSizeOutput.model_validate(
+        {
+            "name": "SP",
+            "signature": "SP(INT)",
+            "size_bytes_raw": 100,
+            "size_bytes_clean": 80,
+            "lines_raw": 10,
+            "lines_clean": 8,
+            "sections_detected": ["header", "body"],
+            "duration_ms": 5,
+        }
+    )
+    assert out.size_bytes_raw == 100
+    assert out.sections_detected == ["header", "body"]
+
+
+@pytest.mark.contract
+def test_size_output_rejects_extra_fields() -> None:
+    import pydantic
+
+    with pytest.raises(pydantic.ValidationError):
+        GetProcedureSizeOutput.model_validate(
+            {
+                "name": "SP",
+                "signature": "SP(INT)",
+                "size_bytes_raw": 100,
+                "size_bytes_clean": 80,
+                "lines_raw": 10,
+                "lines_clean": 8,
+                "sections_detected": [],
                 "duration_ms": 0,
                 "unexpected_field": True,
             }

--- a/tests/unit/test_tools_procedures.py
+++ b/tests/unit/test_tools_procedures.py
@@ -339,9 +339,7 @@ def test_nz_get_procedure_ddl_sizes_always_present(
 # ── nz_get_procedure_size ─────────────────────────────────────────────────────
 
 
-def test_nz_get_procedure_size_happy(
-    monkeypatch: pytest.MonkeyPatch, two_profiles: Path
-) -> None:
+def test_nz_get_procedure_size_happy(monkeypatch: pytest.MonkeyPatch, two_profiles: Path) -> None:
     """Standard procedure returns metrics without body."""
     # We mock the low level fetch/pick to test the actual catalog logic
     row = {

--- a/tests/unit/test_tools_procedures.py
+++ b/tests/unit/test_tools_procedures.py
@@ -13,10 +13,12 @@ from nz_mcp.tools.procedures import (
     GetProcedureDdlInput,
     GetProceduresDdlBatchInput,
     GetProcedureSectionInput,
+    GetProcedureSizeInput,
     ListProceduresInput,
     nz_describe_procedure,
     nz_get_procedure_ddl,
     nz_get_procedure_section,
+    nz_get_procedure_size,
     nz_get_procedures_ddl_batch,
     nz_list_procedures,
 )
@@ -332,3 +334,94 @@ def test_nz_get_procedure_ddl_sizes_always_present(
         assert out.size_bytes_raw >= 0
         assert out.size_bytes_clean >= 0
         assert out.size_bytes_raw >= out.size_bytes_clean
+
+
+# ── nz_get_procedure_size ─────────────────────────────────────────────────────
+
+
+def test_nz_get_procedure_size_happy(
+    monkeypatch: pytest.MonkeyPatch, two_profiles: Path
+) -> None:
+    """Standard procedure returns metrics without body."""
+    # We mock the low level fetch/pick to test the actual catalog logic
+    row = {
+        "PROCEDURE": "MY_SP",
+        "PROCEDURESIGNATURE": "MY_SP()",
+        "ARGUMENTS": "",
+        "RETURNS": "INT",
+        "PROCEDURESOURCE": "BEGIN_PROC\n  BEGIN\n    x := 1;\n  END;\nEND_PROC;",
+        "OWNER": "ADMIN",
+    }
+    monkeypatch.setattr("nz_mcp.catalog.procedures._fetch_procedure_rows", lambda *a, **k: [row])
+    monkeypatch.setattr("nz_mcp.catalog.procedures._pick_procedure_row", lambda *a, **k: row)
+
+    out = nz_get_procedure_size(
+        GetProcedureSizeInput(
+            database="D",
+            procedure_schema="PUBLIC",
+            procedure="MY_SP",
+        ),
+        config_path=two_profiles,
+    )
+    assert out.name == "MY_SP"
+    assert out.signature == "MY_SP()"
+    assert out.size_bytes_raw > 0
+    assert out.size_bytes_clean == out.size_bytes_raw
+    assert out.lines_raw == out.lines_clean
+    assert "body" in out.sections_detected
+
+
+def test_nz_get_procedure_size_with_comments(
+    monkeypatch: pytest.MonkeyPatch, two_profiles: Path
+) -> None:
+    """Procedure with comments must reflect clean < raw metrics."""
+    row = {
+        "PROCEDURE": "SP_COMMENTS",
+        "PROCEDURESIGNATURE": "SP_COMMENTS()",
+        "ARGUMENTS": "",
+        "RETURNS": "INT",
+        "PROCEDURESOURCE": (
+            "BEGIN_PROC\n  BEGIN\n    -- c1\n    -- c2\n    -- c3\n    x := 1;\n  END;\nEND_PROC;"
+        ),
+        "OWNER": "ADMIN",
+    }
+    monkeypatch.setattr("nz_mcp.catalog.procedures._fetch_procedure_rows", lambda *a, **k: [row])
+    monkeypatch.setattr("nz_mcp.catalog.procedures._pick_procedure_row", lambda *a, **k: row)
+
+    out = nz_get_procedure_size(
+        GetProcedureSizeInput(
+            database="D",
+            procedure_schema="PUBLIC",
+            procedure="SP_COMMENTS",
+        ),
+        config_path=two_profiles,
+    )
+    assert out.size_bytes_clean < out.size_bytes_raw
+    assert out.lines_clean < out.lines_raw
+
+
+def test_nz_get_procedure_size_with_overload(
+    monkeypatch: pytest.MonkeyPatch, two_profiles: Path
+) -> None:
+    """Overloads must be resolvable via signature."""
+    row = {
+        "PROCEDURE": "SP_OVERLOAD",
+        "PROCEDURESIGNATURE": "SP_OVERLOAD(INT)",
+        "ARGUMENTS": "(INT)",
+        "RETURNS": "INT",
+        "PROCEDURESOURCE": "BEGIN_PROC\n  BEGIN\n  END;\nEND_PROC;",
+        "OWNER": "ADMIN",
+    }
+    monkeypatch.setattr("nz_mcp.catalog.procedures._fetch_procedure_rows", lambda *a, **k: [row])
+    monkeypatch.setattr("nz_mcp.catalog.procedures._pick_procedure_row", lambda *a, **k: row)
+
+    out = nz_get_procedure_size(
+        GetProcedureSizeInput(
+            database="D",
+            procedure_schema="PUBLIC",
+            procedure="SP_OVERLOAD",
+            signature="SP_OVERLOAD(INT)",
+        ),
+        config_path=two_profiles,
+    )
+    assert out.signature == "SP_OVERLOAD(INT)"


### PR DESCRIPTION
## ¿Qué cambia?

Implementa la nueva tool `nz_get_procedure_size` (Issue #106), que provee las métricas de tamaño (líneas y bytes en sus variantes `raw` y `clean`) y detecta las secciones lógicas de un procedimiento almacenado sin retornar su cuerpo completo. Esta metadata es crucial para realizar *token budgeting* antes de descargar DDLs que puedan ser muy largos o superar el límite del contexto IA.

## Issue relacionado
Closes #106

## Acción según AGENTS.md
- **Ruta (keywords)**: `procedimiento`, `stored procedure`, `SP`, `procedure`, `tamaño`, `metadata`, `nueva tool`
- **Docs leídos**:
  - docs/architecture/tools-contract.md
  - docs/roles/data-engineer.md
  - docs/architecture/security-model.md
  - docs/actions/add-tool.md
  - docs/standards/coding.md
  - docs/standards/maintainability.md
  - docs/standards/testing.md
  - docs/standards/pr-audit.md
  - docs/standards/git-workflow.md
- **Rol asumido**: Data Engineer (catálogo y metadata) + Backend Developer (schema pydantic, tools layer)

## Archivos esperados (según el issue)
- [x] `docs/adr/0010-tool-procedure-size.md` (nuevo) — decisión de separar tool de metadata.
- [x] `src/nz_mcp/catalog/procedures.py` — añade `get_procedure_size`.
- [x] `src/nz_mcp/tools/procedures.py` — esquemas `GetProcedureSizeInput`, `GetProcedureSizeOutput` y handler `nz_get_procedure_size`.
- [x] `tests/unit/test_tools_procedures.py` — unit tests para la lógica de sizes/lines.
- [x] `tests/contract/test_procedures_contract.py` — tests de contrato wire-level.
- [x] `docs/architecture/tools-contract.md` — documentada herramienta en sección 14.
- [x] `CHANGELOG.md` — entrada bilingüe en Unreleased.

Archivo no esperado por el issue pero tocado: ninguno.

## Auditoría pre-merge — 7 dimensiones

### 1. Contrato y compatibilidad
- [x] Si toca tools: `docs/architecture/tools-contract.md` actualizado en este PR.
- [x] Si hay cambio observable: `CHANGELOG.md` con entrada bilingüe en `Unreleased`.
- [x] Sin breaking change inesperado. 

### 2. Seguridad
- [x] Todo SQL pasa por `sql_guard.validate()`. (Reutiliza la capa de fetching de DDL)
- [x] Sin SQL concatenado (parametrizado).
- [x] Sin credenciales en código, logs, tests, fixtures, comentarios.

### 3. Mantenibilidad y diseño
- [x] Toqué solo los archivos esperados.
- [x] Sin abstracciones nuevas sin 3 usos reales. Reutiliza lógica base de `strip_comments` y `parse_sections`.
- [x] Sin dependencias nuevas sin ADR.
- [x] Funciones < 50 LoC, args < 4.
- [x] Una intención por PR.

### 4. Tests
- [x] Tests para todo comportamiento nuevo.
- [x] `pytest -m "not integration"` verde local.
- [x] Cobertura ≥ 85 % global, no cae respecto a `main`.
- [x] Sin `pytest.skip()` ni `xfail` sin issue.

### 5. Tipado y estilo
- [x] `ruff check .` y `ruff format --check .` limpios.
- [x] `mypy --strict` limpio en módulos tocados.
- [x] Sin `Any` en superficies públicas sin justificación.
- [x] Sin `except Exception:` sin re-raise tipado.

### 6. Documentación
- [x] Si cambia API pública: `tools-contract.md` actualizado.
- [x] Si cambia comportamiento: `CHANGELOG.md` actualizado (ES + EN).
- [x] Si introduce decisión arquitectónica: nuevo ADR en `docs/adr/0010-tool-procedure-size.md`.
- [x] Mensajes nuevos: claves añadidas en ES **y** EN. (N/A)

### 7. Idioma y forma
- [x] Título de PR en español, formato conventional commit.
- [x] Branch cumple regex (validado por CI): `feat/106-procedure-size`.
- [x] Commits en español, conventional (validados por CI).
- [x] Código y comentarios en inglés.

## Validación humana requerida
- [ ] No requiere validación manual.

## Notas para el auditor
- El CI de lint fallaba por formato, ya se introdujo un commit `chore: format tests...` para dejarlo en verde.
- Se actualizó el título del PR al español ("implementa").
- La metadata se abstrajo como una tool ligera según lo descrito en ADR-0010.
