### PR TITLE
fix(catalog): corrige IndexError en parse_sections con strings multilínea

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,10 @@ Cada entrada se documenta en **español** y **english**.
 - ES: ``nz_create_table`` — por defecto ``dry_run=true``; para ejecutar en el servidor hace falta ``dry_run=false`` y ``confirm=true``. Salida alineada con otras tools DDL: ``ddl_to_execute``, ``executed``, ``duration_ms``.
 - EN: ``nz_create_table`` — defaults to ``dry_run=true``; execution requires ``dry_run=false`` and ``confirm=true``. Output aligned with other DDL tools: ``ddl_to_execute``, ``executed``, ``duration_ms``.
 
+### Fixed
+- ES: ``parse_sections`` — corrige ``IndexError`` en ``_find_plain_outer_end`` y ``_first_plain_begin`` al procesar SPs con literales de string multilínea. ``mask_single_quoted_strings`` colapsa newlines dentro de ``'…'`` en espacios, haciendo ``masked.splitlines()`` más corto que ``source.splitlines()``; el loop usaba el conteo del source como límite pero indexaba en masked (issue #113).
+- EN: ``parse_sections`` — fix ``IndexError`` in ``_find_plain_outer_end`` and ``_first_plain_begin`` when processing SPs containing multi-line string literals. ``mask_single_quoted_strings`` collapses newlines inside ``'…'`` to spaces, making ``masked.splitlines()`` shorter than ``source.splitlines()``; the loop used the source line count as its bound but indexed into masked lines (issue #113).
+
 ### Added
 - ES: tool ``nz_get_procedures_ddl_batch`` para obtener los DDL de todos los procedimientos de un schema en lote, reduciendo la carga en indexación masiva (issue #101).
 - EN: ``nz_get_procedures_ddl_batch`` tool to batch fetch DDLs for all procedures in a schema, reducing load during bulk indexing (issue #101).

--- a/src/nz_mcp/catalog/nzplsql_parser.py
+++ b/src/nz_mcp/catalog/nzplsql_parser.py
@@ -70,7 +70,7 @@ def parse_sections(source: str) -> dict[str, tuple[int, int]]:
     if begin_proc_line is not None:
         return _parse_sections_begin_proc_markers(masked_lines, lines, n, begin_proc_line)
 
-    return _parse_sections_plain_nzplsql(masked_lines, n)
+    return _parse_sections_plain_nzplsql(masked_lines)
 
 
 def _parse_sections_begin_proc_markers(
@@ -131,17 +131,16 @@ def _parse_sections_begin_proc_markers(
 
 def _parse_sections_plain_nzplsql(
     masked_lines: list[str],
-    n: int,
 ) -> dict[str, tuple[int, int]]:
     declare_line = _first_line_matching(masked_lines, _DECLARE)
     start_search = 1 if declare_line is None else declare_line + 1
-    main_begin_line = _first_plain_begin(masked_lines, start_search, n)
+    main_begin_line = _first_plain_begin(masked_lines, start_search)
     if main_begin_line is None:
         return {}
 
     exception_line = _first_line_matching_after(masked_lines, _EXCEPTION, main_begin_line + 1)
 
-    closing_end_line = _find_plain_outer_end(masked_lines, main_begin_line, n)
+    closing_end_line = _find_plain_outer_end(masked_lines, main_begin_line)
     if closing_end_line is None:
         return {}
 
@@ -169,8 +168,10 @@ def _parse_sections_plain_nzplsql(
     return sections
 
 
-def _first_plain_begin(masked_lines: list[str], start_line: int, n: int) -> int | None:
-    for i in range(start_line, n + 1):
+def _first_plain_begin(masked_lines: list[str], start_line: int) -> int | None:
+    # Use len(masked_lines) as the bound — *not* the source line count, which
+    # can be larger when multi-line string literals are collapsed by masking.
+    for i in range(start_line, len(masked_lines) + 1):
         line = masked_lines[i - 1]
         if _BEGIN_PROC.search(line):
             continue
@@ -179,11 +180,18 @@ def _first_plain_begin(masked_lines: list[str], start_line: int, n: int) -> int 
     return None
 
 
-def _find_plain_outer_end(masked_lines: list[str], main_begin_line: int, n: int) -> int | None:
-    """Find the ``END;`` that closes the outer ``BEGIN`` at ``main_begin_line``."""
+def _find_plain_outer_end(masked_lines: list[str], main_begin_line: int) -> int | None:
+    """Find the ``END;`` that closes the outer ``BEGIN`` at ``main_begin_line``.
+
+    Uses ``len(masked_lines)`` as the loop bound instead of the source line
+    count.  ``mask_single_quoted_strings`` replaces newlines inside string
+    literals with spaces, so ``masked.splitlines()`` can be shorter than
+    ``source.splitlines()``.  Using the source count caused ``IndexError``
+    for procedures containing multi-line string literals (see issue #113).
+    """
     depth = 1
     i = main_begin_line + 1
-    while i <= n:
+    while i <= len(masked_lines):
         ml = masked_lines[i - 1]
         if _line_is_nested_end_keyword(ml):
             i += 1

--- a/tests/unit/test_nzplsql_parse_sections.py
+++ b/tests/unit/test_nzplsql_parse_sections.py
@@ -1,0 +1,150 @@
+"""Regression tests for parse_sections with multi-line string literals (#113).
+
+``mask_single_quoted_strings`` replaces newlines inside ``'…'`` with spaces,
+so ``masked.splitlines()`` can be shorter than ``source.splitlines()``.
+Before the fix, ``_first_plain_begin`` and ``_find_plain_outer_end`` used
+the *source* line count as their loop bound, causing ``IndexError`` when
+the loop advanced past the end of the (shorter) masked-lines list.
+"""
+
+from __future__ import annotations
+
+from nz_mcp.catalog.nzplsql_parser import parse_sections
+
+# ── _find_plain_outer_end crash path ─────────────────────────────────────────
+
+
+def test_multiline_string_no_outer_end_returns_empty() -> None:
+    """SP body with a multi-line string but no closing ``END;``.
+
+    Before the fix this raised ``IndexError`` because the loop bound
+    (source line count = 7) exceeded ``len(masked_lines)`` (= 4).
+    """
+    src = "DECLARE x INT;\nBEGIN\n  v := 'line1\nline2\nline3\nline4';\n  NULL;"
+    assert parse_sections(src) == {}
+
+
+def test_multiline_string_with_valid_outer_end() -> None:
+    """Multi-line string inside the body, outer ``END;`` present."""
+    src = "DECLARE x INT;\nBEGIN\n  v := 'a\nb\nc';\n  NULL;\nEND;"
+    sec = parse_sections(src)
+    assert "declare" in sec
+    assert "body" in sec
+
+
+def test_multiline_string_nested_begin_end() -> None:
+    """Nested ``BEGIN`` / ``END;`` with a multi-line string inside."""
+    src = (
+        "DECLARE x INT;\n"
+        "BEGIN\n"
+        "  BEGIN\n"
+        "    v := 'a\nb\nc\nd\ne';\n"
+        "    NULL;\n"
+        "  END;\n"
+        "  NULL;\n"
+        "END;"
+    )
+    sec = parse_sections(src)
+    assert "declare" in sec
+    assert "body" in sec
+    # Section ranges refer to masked-line numbers, so we only check that
+    # the body starts after BEGIN and ends before the outer END;.
+    assert sec["body"][0] > sec["declare"][1]
+
+
+# ── _first_plain_begin crash path ────────────────────────────────────────────
+
+
+def test_multiline_string_in_declare_no_begin_returns_empty() -> None:
+    """Multi-line string in DECLARE, no ``BEGIN`` at all.
+
+    Before the fix this raised ``IndexError`` in ``_first_plain_begin``
+    because the loop bound (source line count = 6) exceeded
+    ``len(masked_lines)`` (= 2).
+    """
+    src = "DECLARE\n  v VARCHAR := 'line1\nline2\nline3\nline4\nline5';"
+    assert parse_sections(src) == {}
+
+
+def test_multiline_string_in_declare_with_begin() -> None:
+    """Multi-line string in DECLARE, followed by a valid ``BEGIN`` / ``END;``."""
+    src = "DECLARE\n  v VARCHAR := 'a\nb\nc';\nBEGIN\n  NULL;\nEND;"
+    sec = parse_sections(src)
+    assert "declare" in sec
+    assert "body" in sec
+
+
+# ── large SP simulation ──────────────────────────────────────────────────────
+
+
+def test_large_sp_many_multiline_strings() -> None:
+    """Simulate a large SP with several multi-line string literals.
+
+    Ensures the parser handles the cumulative line-count difference
+    between source and masked output without crashing.
+    """
+    assignments = []
+    for i in range(10):
+        # Each string literal spans 6 source lines but collapses to 1 masked line.
+        assignments.append(f"  v{i} := 'line1\nline2\nline3\nline4\nline5\nline6';")
+    body = "\n".join(assignments)
+    src = f"DECLARE x INT;\nBEGIN\n{body}\n  NULL;\nEND;"
+
+    sec = parse_sections(src)
+    assert "body" in sec
+
+
+def test_large_sp_nested_blocks_with_multiline_strings() -> None:
+    """Nested blocks interleaved with multi-line strings."""
+    src = (
+        "DECLARE x INT;\n"
+        "BEGIN\n"
+        "  v1 := 'a\nb\nc';\n"
+        "  BEGIN\n"
+        "    v2 := 'd\ne\nf';\n"
+        "    NULL;\n"
+        "  END;\n"
+        "  v3 := 'g\nh\ni';\n"
+        "  BEGIN\n"
+        "    NULL;\n"
+        "  END;\n"
+        "  NULL;\n"
+        "END;"
+    )
+    sec = parse_sections(src)
+    assert "body" in sec
+
+
+# ── edge cases ───────────────────────────────────────────────────────────────
+
+
+def test_multiline_string_with_exception_block() -> None:
+    """Multi-line string in body, followed by EXCEPTION block."""
+    src = (
+        "DECLARE x INT;\n"
+        "BEGIN\n"
+        "  v := 'a\nb\nc';\n"
+        "  SELECT 1;\n"
+        "EXCEPTION\n"
+        "  WHEN OTHERS THEN\n"
+        "    NULL;\n"
+        "END;"
+    )
+    sec = parse_sections(src)
+    assert "body" in sec
+    assert "exception" in sec
+
+
+def test_multiline_string_spanning_many_lines() -> None:
+    """Single string literal spanning many lines (extreme case)."""
+    inner = "\n".join(f"line{i}" for i in range(50))
+    src = f"DECLARE x INT;\nBEGIN\n  v := '{inner}';\n  NULL;\nEND;"
+    sec = parse_sections(src)
+    assert "body" in sec
+
+
+def test_empty_multiline_string() -> None:
+    """String literal containing only newlines."""
+    src = "DECLARE x INT;\nBEGIN\n  v := '\n\n\n';\n  NULL;\nEND;"
+    sec = parse_sections(src)
+    assert "body" in sec


### PR DESCRIPTION
## ¿Qué cambia?

`_first_plain_begin` y `_find_plain_outer_end` usaban `n` (conteo de líneas del source original) como límite del loop, pero iteraban sobre `masked_lines` que puede ser más corto cuando el source contiene literales de string multilínea. `mask_single_quoted_strings` reemplaza newlines dentro de `'…'` con espacios, colapsando esas líneas. Cuando el loop avanzaba más allá de `len(masked_lines)`, se producía `IndexError`. Ambas funciones ahora usan `len(masked_lines)` como límite.

## Issue relacionado
Closes #113

## Acción según AGENTS.md
- **Ruta (keywords)**: `procedimiento`, `stored procedure`, `SP`, `parser`, `bug`
- **Docs leídos**:
  - `docs/architecture/tools-contract.md`
  - `docs/roles/data-engineer.md`
  - `docs/standards/coding.md`
  - `docs/standards/testing.md`
  - `docs/standards/pr-audit.md`
  - `src/nz_mcp/catalog/nzplsql_parser.py` (lectura completa antes de modificar)
- **Rol asumido**: Data Engineer (parser NZPLSQL) + QA Engineer (regression tests)

## Archivos esperados (según el issue)
- `src/nz_mcp/catalog/nzplsql_parser.py` — fix en `_find_plain_outer_end` y `_first_plain_begin` (cambio de límite del loop de `n` a `len(masked_lines)`); eliminación del parámetro `n` de `_parse_sections_plain_nzplsql`
- `tests/unit/test_nzplsql_parse_sections.py` — **nuevo**, 10 regression tests
- `CHANGELOG.md` — entrada bilingüe en `Unreleased / Fixed`

## Auditoría pre-merge — 7 dimensiones

### 1. Contrato y compatibilidad
- [x] Si toca tools: `docs/architecture/tools-contract.md` actualizado en este PR. — No toca tools, solo parser interno.
- [x] Si hay cambio observable: `CHANGELOG.md` con entrada bilingüe en `Unreleased`.
- [x] Sin breaking change inesperado.

### 2. Seguridad
- [x] Todo SQL pasa por `sql_guard.validate()`. — No aplica, no se toca SQL.
- [x] Sin SQL concatenado (parametrizado). — No aplica.
- [x] Sin credenciales en código, logs, tests, fixtures, comentarios.
- [x] Si toca `sql_guard.py` o `auth.py`: cobertura sigue en 100 %. — No aplica.
- [x] Si toca `sql_guard.py`: ≥ 3 tests adversariales nuevos. — No aplica.

### 3. Mantenibilidad y diseño
- [x] Toqué solo los archivos esperados (o documenté por qué no).
- [x] Sin abstracciones nuevas sin 3 usos reales.
- [x] Sin dependencias nuevas sin ADR.
- [x] Funciones < 50 LoC, args < 4.
- [x] Una intención por PR.
- [x] PR < 400 LoC sin tests/docs (o justificado). — ~10 LoC de cambio en parser, ~150 LoC de tests.

### 4. Tests
- [x] Tests para todo comportamiento nuevo.
- [x] `pytest -m "not integration"` verde local. — 625 passed.
- [x] Cobertura ≥ 85 % global, no cae respecto a `main`. — 85.58%.
- [x] Sin `pytest.skip()` ni `xfail` sin issue.

### 5. Tipado y estilo
- [x] `ruff check .` y `ruff format --check .` limpios.
- [x] `mypy --strict` limpio en módulos tocados.
- [x] Sin `Any` en superficies públicas sin justificación.
- [x] Sin `except Exception:` sin re-raise tipado.

### 6. Documentación
- [x] Si cambia API pública: `tools-contract.md` actualizado. — No cambia API pública.
- [x] Si cambia comportamiento: `CHANGELOG.md` actualizado (ES + EN).
- [x] Si introduce decisión arquitectónica: nuevo ADR en `docs/adr/`. — No aplica.
- [x] Mensajes nuevos: claves añadidas en ES **y** EN. — No aplica.

### 7. Idioma y forma
- [x] Título de PR en español, formato conventional commit.
- [x] Branch cumple regex (validado por CI).
- [x] Commits en español, conventional (validados por CI).
- [x] Código y comentarios en inglés.

## Validación humana requerida
- [x] Sí — explicar por qué: E2E contra Netezza real (`PI_BASEREPERFILAMIENTOGENERAL`) no fue posible por falta de acceso al entorno de producción. El maintainer debe ejecutar las 2 verificaciones E2E del issue antes de merge.
- [ ] No

## Notas para el auditor
- **Causa raíz**: `mask_single_quoted_strings` reemplaza `\n` dentro de `'…'` con espacios, haciendo que `masked.splitlines()` sea más corto que `source.splitlines()`. Las funciones `_first_plain_begin` y `_find_plain_outer_end` usaban el conteo de líneas del source (`n`) como límite del loop pero indexaban en `masked_lines`.
- **Limitación conocida pre-existente**: los números de línea en las secciones retornadas por `parse_sections` (path plain) refieren a posiciones en `masked_lines`, no en el source original. Esto es un diseño pre-existente, no introducido por este fix. El issue dice explícitamente "no cambiar la semántica para inputs válidos".
- **Riesgo**: bajo. El cambio solo afecta el path plain (sin `BEGIN_PROC`). El path con marcadores `BEGIN_PROC`/`END_PROC` no está afectado.